### PR TITLE
Holistic docs cleanup based on PR review feedback

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,6 @@
 
 ## Checklist
 
-- [ ] Ran `make lint` and `make build` successfully
+- [ ] Ran `make check` successfully (lint + unit tests + build)
 - [ ] Included screenshot if I made a UX change
 - [ ] Updated documentation if applicable

--- a/.github/agents/copilot-coding-agent.md
+++ b/.github/agents/copilot-coding-agent.md
@@ -36,7 +36,7 @@ Based on the request, do what's appropriate:
 
 - **Answer questions** about the codebase — find the relevant code and explain it.
 - **Debug reported problems** — reproduce locally, run required repo commands (lint/build/test) from README, CONTRIBUTING, DEVELOPING, Makefile, or CI config, and trace the code path.
-- **Implement changes** — make the changes and verify they work by running `make lint` and `make build`.
+- **Implement changes** — make the changes and verify they work by running `make check` (lint + unit tests + build).
 - **Clarify requirements** — ask follow-up questions if the request is ambiguous.
 
 ### Step 3: Verify Changes
@@ -52,21 +52,30 @@ Before finishing:
 
 ### Screenshots for UI Changes
 
-When a change affects the visual appearance of the dashboard, you **must** capture and attach before/after screenshots to the pull request. Run the screenshot preflight first to check for errors:
+When a change affects the visual appearance of the dashboard, you **must** capture and attach before/after screenshots to the pull request.
+
+1. Start the dev server in the background:
+
+```bash
+cd peek && npm run dev &
+```
+
+2. Wait a few seconds for the server to be ready, then run the screenshot preflight:
 
 ```bash
 cd peek && node scripts/screenshot-preflight.mjs --url http://127.0.0.1:3000 --output screenshot-preflight.json --screenshot screenshot.png
 ```
 
-If the preflight reports errors, attach the diagnostics JSON instead. If it passes, attach the captured screenshot to the PR body.
+3. If the preflight reports errors, attach the diagnostics JSON instead. If it passes, attach the captured screenshot to the PR body.
 
 For this repository:
 
 ```bash
-make setup   # install dependencies
-make serve   # start dev server
-make build   # production build
-make lint    # Prettier + ESLint + TypeScript type checking
-make format  # auto-format code with Prettier
-make check   # run all checks then build (equivalent to CI)
+make setup     # install dependencies
+make serve     # start dev server
+make build     # production build
+make lint      # Prettier + ESLint + TypeScript type checking
+make format    # auto-format code with Prettier
+make test-unit # run unit tests
+make check     # run all checks then build (equivalent to CI)
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,9 +49,7 @@ from ES|QL aggregations like STATS ... BY bucket1, bucket2.
    - Add toggle in `PanelEditor.tsx`
 
 3. **Verify**:
-   - Run `make format` to auto-format code
-   - Run `make lint` to check formatting, lint rules, and types
-   - Run `make build` to confirm production build
+   - Run `make check` to run lint, unit tests, and build
 ```
 
 ### 3. Maintainer Assigns an Agent
@@ -63,7 +61,6 @@ Once approved, a maintainer assigns the issue to an AI agent. The agent creates 
 - **Bugs**: Include reproduction steps, expected vs actual behavior, and proposed fix
 - **Features**: Explain the use case, provide examples, and include step-by-step instructions
 - **Be specific**: Name the files, components, and test cases the agent should touch
-- **UI changes**: Remind the agent to include before/after screenshots in the PR
 
 ## Security
 

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -7,8 +7,12 @@
 | `peek/` | Vite + React 18 + TypeScript frontend application |
 | `peek/src/components/` | React UI components (panels, editors, dialogs) |
 | `peek/src/components/visualizations/` | Chart and table visualization components |
+| `peek/src/dashboards/` | Default dashboard definitions |
+| `peek/src/docs/` | Embedded in-product documentation content |
+| `peek/src/schemas.ts` | Zod validation schemas for import/export |
 | `peek/src/services/` | Elasticsearch ES|QL client |
 | `peek/src/store/` | Zustand state management |
+| `peek/tests/unit/` | Unit tests (Vitest + jsdom) |
 | `peek/tests/integration/` | Integration tests (Testcontainers + Elasticsearch) |
 | `docker/` | nginx config template for the Docker proxy image |
 | `.github/workflows/` | GitHub Actions workflows (CI, GitHub Pages deployment) |
@@ -69,16 +73,9 @@ The dashboard is a static single-page application. Elasticsearch queries are mad
 ### Key Design Decisions
 
 - **No backend**: The site is fully static. The Elasticsearch URL is stored in `localStorage` for persistence, while API key/password are stored in `sessionStorage` and cleared when the tab session ends.
+- **State persistence**: Dashboard state is persisted under the `elastic-peek` localStorage key via Zustand's `persist` middleware. Credentials are split into `sessionStorage` to limit exposure. If you rename the persist key, you must add a one-time migration that reads the old key and writes it to the new one — otherwise existing users lose their saved state.
 - **Perses-aligned**: Uses the same charting engine (Apache ECharts) and UI framework (MUI) as Perses. The theme system and chart patterns follow Perses conventions.
 - **ES|QL native**: Queries are written in ES|QL and sent directly to the `_query` endpoint. The response format (columnar JSON) is transformed into chart-compatible structures client-side.
-
-### Visualization Pipeline
-
-1. User writes an ES|QL query in the panel editor
-2. Query is sent to Elasticsearch via `POST /_query?format=json`
-3. Response columns are classified by type (date, numeric, keyword)
-4. Column types determine how data maps to chart axes and series
-5. ECharts renders the visualization with theme-matched styling
 
 ## Adding a Visualization Type
 
@@ -103,69 +100,20 @@ Or with Docker Compose:
 ES_URL=http://my-elasticsearch:9200 docker compose up
 ```
 
-Open `http://localhost:8080` and enter `http://localhost:8080` as the Elasticsearch URL. The nginx proxy inside the container forwards `/_query` requests to `ES_URL`.
-
-### How the proxy works
-
-- The `Dockerfile` builds the dashboard with `VITE_BASE_PATH=/` (root-relative URLs) and serves it from nginx.
-- `docker/nginx.conf.template` is processed at container startup; `${ES_URL}` is substituted with the `ES_URL` environment variable.
-- nginx routes `/_query` to Elasticsearch and serves everything else as static files.
+Open `http://localhost:8080` and enter `http://localhost:8080` as the Elasticsearch URL. The nginx proxy inside the container forwards `/_query` requests to `ES_URL`. See `docker/nginx.conf.template` for the proxy configuration.
 
 ## Testing
 
-Integration tests use [Testcontainers](https://testcontainers.com/) to spin up a real Elasticsearch instance in Docker, load test data, and run ES|QL queries through the same `executeEsql` service the dashboard uses.
-
-### Prerequisites
-
-- **Docker** must be running locally
-
-### Running Tests
-
 ```bash
-make test
+make test-unit        # fast, no Docker needed — primary CI gate
+make test-integration # requires Docker (spins up Elasticsearch via Testcontainers)
+make test             # run both
 ```
 
-This starts an Elasticsearch 8.17 container, seeds two indices (`web_logs` and `orders`) with sample data, and runs the test suite via Vitest. Container lifecycle is managed automatically — it starts before the first test and stops after the last.
-
-### Test Structure
-
-| File | What |
-| --- | --- |
-| `tests/integration/setup.ts` | Container startup, ES client creation, test data seeding |
-| `tests/integration/esql.test.ts` | ES|QL query tests against our `executeEsql` service |
-
-### What's Tested
-
-- Connection testing (`SHOW INFO`, bad URL)
-- Basic queries (`FROM`, `WHERE`, `SORT`, `LIMIT`)
-- Aggregations (`COUNT`, `SUM`, `AVG`, grouped `STATS ... BY`)
-- Computed columns (`EVAL`)
-- Response structure (column names, types for keyword/integer/long/double)
-- Error handling (invalid syntax returns structured `EsqlError`)
+Unit tests (`peek/tests/unit/`) run in jsdom via Vitest. Integration tests (`peek/tests/integration/`) use [Testcontainers](https://testcontainers.com/) to start a real Elasticsearch instance, seed test data, and run ES|QL queries through the app's `executeEsql` service. **Docker must be running** for integration tests.
 
 ### CI
 
-The `ci.yml` workflow runs `make ci` (lint + unit tests + build) on every push to `main` and on every PR that touches `peek/**`. Integration tests require Docker and are run separately with `make test-integration`.
+`make ci` runs lint + unit tests + build on every push to `main` and on every PR that touches `peek/**`. Integration tests are not part of the default CI pipeline — run them locally with `make test-integration`.
 
-## Code Quality
-
-The project enforces formatting, linting, and type safety. All three are checked in CI on every pull request.
-
-| Tool | Purpose | Config |
-| --- | --- | --- |
-| **Prettier** | Code formatting | `peek/.prettierrc` |
-| **ESLint** | Static analysis (TypeScript + React rules) | `peek/eslint.config.js` |
-| **TypeScript** | Type checking (`strict`, `noUnusedLocals`, `noUnusedParameters`) | `peek/tsconfig.json` |
-
-```bash
-make lint     # run all checks (Prettier, ESLint, TypeScript)
-make format   # auto-fix formatting
-```
-
-## Building for Production
-
-```bash
-make build
-```
-
-Output goes to `peek/dist/`. This directory is deployed to GitHub Pages by the `deploy-pages.yml` workflow on every push to `main`.
+Production builds (`make build`) output to `peek/dist/` and are deployed to GitHub Pages by the `deploy-pages.yml` workflow on every push to `main`.


### PR DESCRIPTION
## Summary

Updates repository documentation based on patterns observed across ~20 recent PRs with review comments or revision requests.

## Changes

**DEVELOPING.md** (172 -> 120 lines, net -52)
- Added missing directories to Repository Structure table: `dashboards/`, `docs/`, `schemas.ts`, `tests/unit/`
- Added State Persistence note under Key Design Decisions (localStorage key migration requirement, credential split)
- Replaced verbose Testing section (file tables, "What's Tested" bullet lists) with concise two-tier overview
- Removed Visualization Pipeline, Code Quality tool table, and Building for Production sections (all redundant with Quick Start or self-evident from code)
- Removed "How the proxy works" nginx internals (pointed to config file instead)

**CONTRIBUTING.md**
- Removed "UI changes: Remind the agent to include screenshots" from Issue Guidelines — this is now the agent's own responsibility
- Consolidated verify steps to just `make check`

**Copilot coding agent prompt**
- Added dev server startup step before screenshot preflight (the agent can't screenshot a URL that isn't running)
- Changed verification command from `make lint` + `make build` to `make check` (includes unit tests)
- Added `make test-unit` to the commands reference

**PR template**
- Replaced separate lint/build checklist items with single `make check` item

## Checklist

- [x] Ran `make check` successfully (lint + unit tests + build)
- [ ] Included screenshot if I made a UX change
- [x] Updated documentation if applicable

Made with [Cursor](https://cursor.com)