### PR TITLE
Add address-pr-feedback workflow

### DIFF
--- a/.github/workflows/pr-review-addresser.yml
+++ b/.github/workflows/pr-review-addresser.yml
@@ -1,4 +1,4 @@
-name: Address PR Feedback
+name: PR Review Addresser
 on:
   pull_request_review:
     types: [submitted]
@@ -14,7 +14,7 @@ jobs:
     if: >-
       (github.event.review.state == 'changes_requested' || github.event.review.state == 'commented') &&
       !github.event.pull_request.draft &&
-      !contains(github.event.pull_request.labels.*.name, 'skip-auto-address-pr-feedback')
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-address-pr-feedback.lock.yml@v0
+      !contains(github.event.pull_request.labels.*.name, 'skip-auto-pr-review-addresser')
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-review-addresser.lock.yml@v0
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/address-pr-feedback.yml` that triggers on PR review submissions
- Fires when a review is `changes_requested` or `commented` on non-draft PRs
- Delegates to the shared `gh-aw-address-pr-feedback.lock.yml` reusable workflow from `elastic/ai-github-actions@v0`
- Skippable via the `skip-auto-address-pr-feedback` label

## Test plan
- [ ] Verify the workflow appears in the Actions tab after merge
- [ ] Submit a review with "changes requested" on a test PR and confirm the workflow runs
- [ ] Confirm draft PRs and PRs with the `skip-auto-address-pr-feedback` label are skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)