### PR TITLE
Fix mention-in-pr-by-id workflow target wiring

### DIFF
--- a/.github/workflows/trigger-mention-in-pr-by-id.yml
+++ b/.github/workflows/trigger-mention-in-pr-by-id.yml
@@ -20,7 +20,7 @@ permissions:
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-mention-in-pr-by-id.lock.yml@main
     with:
       target-pr-number: ${{ inputs.pull-request-number }}
       prompt: ${{ inputs.prompt }}


### PR DESCRIPTION
## Summary
- switch `trigger-mention-in-pr-by-id.yml` to call `gh-aw-mention-in-pr-by-id.lock.yml` instead of the generic mention workflow
- preserve explicit `target-pr-number` routing through the reusable workflow so safe outputs target the intended PR
- prevent `push_to_pull_request_branch` from falling back to `target: triggering` in workflow_dispatch runs

## Test plan
- [x] Compile-time check: workflow YAML is valid after the reference change
- [x] Verified diff only changes the reusable workflow reference in `.github/workflows/trigger-mention-in-pr-by-id.yml`
- [ ] Trigger `trigger-mention-in-pr-by-id` manually and confirm push-to-pull-request-branch succeeds for the specified PR number

Made with [Cursor](https://cursor.com)