### PR TITLE
fix: ES|QL query editor word wrap and input performance

### DIFF
--- a/peek/src/components/DiscoverPage.tsx
+++ b/peek/src/components/DiscoverPage.tsx
@@ -18,7 +18,7 @@ import MenuItem from "@mui/material/MenuItem";
 import AddIcon from "@mui/icons-material/Add";
 import PlayArrowIcon from "@mui/icons-material/PlayArrow";
 import CodeMirror from "@uiw/react-codemirror";
-import type { EditorView } from "@codemirror/view";
+import { EditorView } from "@codemirror/view";
 import { useShallow } from "zustand/react/shallow";
 
 import { useDashboardStore } from "../store/useDashboardStore";
@@ -100,6 +100,7 @@ export default function DiscoverPage() {
     [timeRange],
   );
 
+  const timingsCleared = useRef(false);
   const {
     runQuery,
     loading,
@@ -121,6 +122,7 @@ export default function DiscoverPage() {
       setSelectedFields(new Set(data.columns.map((c) => c.name)));
       setTableVersion((prev) => prev + 1);
       appendQueryToHistory(executedQuery);
+      timingsCleared.current = false;
     },
     onFailure: () => setResult(null),
   });
@@ -131,7 +133,10 @@ export default function DiscoverPage() {
       if (discoverQueryDraft) {
         setDiscoverQueryDraft(null);
       }
-      clearTimings();
+      if (!timingsCleared.current) {
+        clearTimings();
+        timingsCleared.current = true;
+      }
       setQuery(nextQuery);
       setCurrentSort(null);
     },
@@ -167,11 +172,15 @@ export default function DiscoverPage() {
     handleRunQueryRef.current = handleRunQuery;
   }, [handleRunQuery]);
   const queryEditorExtensions = useMemo(
-    () =>
+    () => [
+      EditorView.lineWrapping,
       // eslint-disable-next-line react-hooks/refs -- ref is read at event time, not during render
-      createEsqlQueryEditorExtensions(() => void handleRunQueryRef.current()),
+      ...createEsqlQueryEditorExtensions(() => void handleRunQueryRef.current()),
+    ],
     [],
   );
+  const basicSetup = useMemo(() => ({ lineNumbers: true, foldGutter: false }), []);
+  const handleCreateEditor = useCallback((view: EditorView) => setQueryContextView(view), []);
   useEffect(() => {
     if (!connection || !refreshInterval || !effectiveQuery.trim()) return;
     const id = setInterval(() => {
@@ -298,11 +307,11 @@ export default function DiscoverPage() {
           <CodeMirror
             value={effectiveQuery}
             onChange={handleQueryChange}
-            onCreateEditor={(view) => setQueryContextView(view)}
+            onCreateEditor={handleCreateEditor}
             extensions={queryEditorExtensions}
             theme={themeMode}
             height="100px"
-            basicSetup={{ lineNumbers: true, foldGutter: false }}
+            basicSetup={basicSetup}
           />
         </Box>
         <QueryPipelineSteps

--- a/peek/src/components/PanelEditor.tsx
+++ b/peek/src/components/PanelEditor.tsx
@@ -17,7 +17,7 @@ import Divider from "@mui/material/Divider";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import CodeMirror from "@uiw/react-codemirror";
-import type { EditorView } from "@codemirror/view";
+import { EditorView } from "@codemirror/view";
 import { useShallow } from "zustand/react/shallow";
 
 import { useDashboardStore } from "../store/useDashboardStore";
@@ -144,11 +144,15 @@ function PanelEditorDialog({ panel, editingId }: { panel: PanelDefinition; editi
     handleRunQueryRef.current = handleRunQuery;
   }, [handleRunQuery]);
   const queryEditorExtensions = useMemo(
-    () =>
+    () => [
+      EditorView.lineWrapping,
       // eslint-disable-next-line react-hooks/refs -- ref is read at event time, not during render
-      createEsqlQueryEditorExtensions(() => void handleRunQueryRef.current()),
+      ...createEsqlQueryEditorExtensions(() => void handleRunQueryRef.current()),
+    ],
     [],
   );
+  const basicSetup = useMemo(() => ({ lineNumbers: true, foldGutter: false }), []);
+  const handleCreateEditor = useCallback((view: EditorView) => setQueryContextView(view), []);
 
   const handleSave = useCallback(() => {
     if (!editingId) return;
@@ -250,11 +254,11 @@ function PanelEditorDialog({ panel, editingId }: { panel: PanelDefinition; editi
                 <CodeMirror
                   value={query}
                   onChange={setQuery}
-                  onCreateEditor={(view) => setQueryContextView(view)}
+                  onCreateEditor={handleCreateEditor}
                   extensions={queryEditorExtensions}
                   theme={themeMode}
                   height="120px"
-                  basicSetup={{ lineNumbers: true, foldGutter: false }}
+                  basicSetup={basicSetup}
                 />
               </Box>
               <QueryPipelineSteps

--- a/peek/src/components/visualizations/DataTable.tsx
+++ b/peek/src/components/visualizations/DataTable.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useCallback } from "react";
+import { useMemo, useState, useCallback, memo } from "react";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import IconButton from "@mui/material/IconButton";
@@ -49,7 +49,7 @@ interface Props {
   onSortChange?: (columnName: string, direction: SortDirection | null) => void;
 }
 
-export default function DataTable({
+export default memo(function DataTable({
   data,
   options,
   onExportCsv,
@@ -476,4 +476,4 @@ export default function DataTable({
       </Menu>
     </Box>
   );
-}
+});


### PR DESCRIPTION
## Summary
- Add `EditorView.lineWrapping` to CodeMirror extensions so long ES|QL queries wrap instead of requiring horizontal scrolling (DiscoverPage + PanelEditor)
- Wrap `DataTable` in `React.memo()` to prevent expensive full-table re-renders on every keystroke after a query has been run — this was the root cause of "input handler took Nms" browser warnings
- Memoize `basicSetup` object and `onCreateEditor` callback props to avoid unnecessary CodeMirror reconfiguration on parent re-renders
- Guard `clearTimings()` with a ref so it only fires once per editing session instead of on every keystroke

## Test plan
- [ ] Open Discover page, type a long ES|QL query — verify it wraps within the editor
- [ ] Run a query that returns many rows, then type in the editor — verify no lag or "input handler took" console warnings
- [ ] Open Panel Editor dialog — verify the same word wrap and performance fixes apply
- [ ] Verify LLM ghost-text completions still work after the extension changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)