### PR TITLE
chore: add run-smoke-detectors.sh script

### DIFF
--- a/scripts/run-smoke-detectors.sh
+++ b/scripts/run-smoke-detectors.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# run-smoke-detectors.sh
+#
+# Helper script to manually trigger all Smoke test workflows in this
+# repository via the GitHub CLI (gh).
+#
+# Prerequisites:
+#   - gh CLI installed and authenticated (gh auth login)
+#
+# Usage:
+#   ./scripts/run-smoke-detectors.sh
+#   ./scripts/run-smoke-detectors.sh --repo elastic/ai-github-actions-playground
+
+set -euo pipefail
+
+REPO="${REPO:-}"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      REPO="$2"
+      shift 2
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Usage: $0 [--repo <owner/repo>]" >&2
+      exit 1
+      ;;
+  esac
+done
+
+REPO_ARGS=()
+if [[ -n "$REPO" ]]; then
+  REPO_ARGS=(--repo "$REPO")
+fi
+
+# Smoke test workflows that support workflow_dispatch
+WORKFLOWS=(
+  "smoke-auth-tab-switch.yml"
+  "smoke-metrics-flow.yml"
+  "smoke-reset-visibility.yml"
+  "smoke-traces-flow.yml"
+  "smoke-welcome-flow.yml"
+)
+
+# Verify gh is available
+if ! command -v gh &>/dev/null; then
+  echo "Error: gh CLI is not installed. See https://cli.github.com/" >&2
+  exit 1
+fi
+
+echo "Triggering Smoke test workflows..."
+echo ""
+
+FAILED=()
+for workflow in "${WORKFLOWS[@]}"; do
+  printf "  %-45s" "$workflow"
+  if output=$(gh workflow run "$workflow" ${REPO_ARGS[@]+"${REPO_ARGS[@]}"} 2>&1); then
+    echo "✓ triggered"
+  else
+    echo "✗ failed"
+    echo "    $output" >&2
+    FAILED+=("$workflow")
+  fi
+done
+
+echo ""
+if [[ ${#FAILED[@]} -eq 0 ]]; then
+  echo "All smoke workflows triggered successfully."
+else
+  echo "The following workflows could not be triggered:" >&2
+  for w in "${FAILED[@]}"; do
+    echo "  - $w" >&2
+  done
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- Add `scripts/run-smoke-detectors.sh` to manually trigger all 5 smoke test workflows via `workflow_dispatch`
- Mirrors the pattern of the existing `scripts/run-detectors.sh` for detector/auditor workflows
- Supports `--repo` flag for cross-repo dispatch

## Test plan
- [ ] Run `./scripts/run-smoke-detectors.sh` and verify all 5 smoke workflows are triggered
- [ ] Run with `--repo elastic/ai-github-actions-playground` to test explicit repo targeting

🤖 Generated with [Claude Code](https://claude.com/claude-code)