### PR TITLE
fix: replace unsupported --commit flag in gh run list

### DIFF
--- a/scripts/ready-prs-and-enable-workflows.sh
+++ b/scripts/ready-prs-and-enable-workflows.sh
@@ -109,9 +109,9 @@ else
     [[ -z "$pr_number" ]] && continue
     echo "  PR #$pr_number: $pr_title"
 
-    ACTION_REQUIRED_RUNS=$(gh run list "${REPO_ARGS[@]}" --limit 200 --commit "$pr_sha" \
-      --json databaseId,status,workflowName,event \
-      --jq '.[] | select(.event == "pull_request" and .status == "action_required") | "\(.databaseId)\t\(.workflowName)"')
+    ACTION_REQUIRED_RUNS=$(gh run list "${REPO_ARGS[@]}" --limit 200 \
+      --json databaseId,status,workflowName,event,headSha \
+      --jq '.[] | select(.event == "pull_request" and .status == "action_required" and .headSha == "'"$pr_sha"'") | "\(.databaseId)\t\(.workflowName)"')
 
     if [[ -z "$ACTION_REQUIRED_RUNS" ]]; then
       echo "    No runs awaiting approval."


### PR DESCRIPTION
## Summary
- `gh run list` does not support the `--commit` flag, causing the `ready-prs-and-enable-workflows.sh` script to fail
- Replaced with a `headSha` jq filter to achieve the same commit-scoped filtering

## Test plan
- [ ] Run `./scripts/ready-prs-and-enable-workflows.sh --repo elastic/ai-github-actions-playground` and verify no `unknown flag` error

🤖 Generated with [Claude Code](https://claude.com/claude-code)