### PR TITLE
Fix pr-actions-detective permission: pull-requests write → read

### DIFF
--- a/.github/workflows/pr-actions-detective.yml
+++ b/.github/workflows/pr-actions-detective.yml
@@ -8,7 +8,7 @@ permissions:
   actions: read
   contents: read
   issues: write
-  pull-requests: write
+  pull-requests: read
 
 jobs:
   run:


### PR DESCRIPTION
## Summary
- Changes `pull-requests: write` to `pull-requests: read` in `pr-actions-detective.yml` — this workflow only needs read access

## Context
Detected by downstream upgrade check: elastic/ai-github-actions-cannon#12

## Test plan
- [ ] Verify pr-actions-detective workflow still triggers and runs successfully on a failed CI run