### PR TITLE
fix: stabilize live ES smoke tests from CI feedback

### DIFF
--- a/peek/tests/e2e/smoke-live-es.spec.ts
+++ b/peek/tests/e2e/smoke-live-es.spec.ts
@@ -46,10 +46,10 @@ test.describe("smoke – live Elasticsearch", () => {
   test("Cluster Overview shows real node data", async ({ page }) => {
     const consoleLogs = collectConsoleLogs(page);
     await connectToLiveCluster(page);
-    // Already on Cluster Overview after connect
-    await page.waitForLoadState("networkidle");
-    // Cluster health should be visible (green or yellow)
-    await expect(page.getByText(/green|yellow/i).first()).toBeVisible({ timeout: 10_000 });
+    // Already on Cluster Overview after connect — wait for health chip to render
+    await expect(page.getByText(/Status:\s*(GREEN|YELLOW)/i).first()).toBeVisible({
+      timeout: 15_000,
+    });
     await page.screenshot({
       path: "test-results/live-es-cluster-overview.png",
       fullPage: true,
@@ -65,7 +65,7 @@ test.describe("smoke – live Elasticsearch", () => {
     await page.getByRole("button", { name: "Indices", exact: true }).click();
     await page.waitForLoadState("networkidle");
     await expect(page.getByText("web_logs")).toBeVisible({ timeout: 10_000 });
-    await expect(page.getByText("orders")).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText("orders", { exact: true })).toBeVisible({ timeout: 10_000 });
     await page.screenshot({
       path: "test-results/live-es-indices.png",
       fullPage: true,


### PR DESCRIPTION
## Summary

- Fix Cluster Overview test: match `Status: GREEN/YELLOW` chip text instead of bare `green/yellow` regex
- Fix Indices test: use `{ exact: true }` for `"orders"` to avoid strict mode violation when `order_id` fields also match

## Context

These failures were found by running the live ES smoke tests in CI via issue #823. The agent successfully set up the OTLP replay stack and ran all tests, but 2 of 7 failed:

1. **Cluster Overview**: `getByText(/green|yellow/i)` didn't match because health renders as `Status: GREEN` in a MUI Chip
2. **Indices**: `getByText("orders")` matched 2 elements (index name + order_id field content)

## Test plan

- [ ] Re-run live ES smoke tests via `/ai` on #823 to verify both tests now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)