### PR TITLE
chore: distinct skip label + concurrency for PR auto-addressing

### DIFF
--- a/.github/workflows/address-pr-review-feedback.yml
+++ b/.github/workflows/address-pr-review-feedback.yml
@@ -3,6 +3,10 @@ on:
   pull_request_review:
     types: [submitted]
 
+concurrency:
+  group: pr-address-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 permissions:
   actions: read
   contents: write


### PR DESCRIPTION
## Summary
- Change `address-pr-review-feedback` to use `skip-auto-pr-address` label (separate from `skip-auto-pr-review` used by the review workflow) so each can be skipped independently
- Add `concurrency` group keyed on PR number with `cancel-in-progress: true` so stale addresser runs are cancelled when new bot reviews arrive
- Created the `skip-auto-pr-address` label in the repo

## Test plan
- [ ] Apply `skip-auto-pr-address` label to a PR — addresser should skip
- [ ] Apply `skip-auto-pr-review` label — addresser should still run, only review skips
- [ ] Verify concurrent bot reviews on same PR cancel the older addresser run

🤖 Generated with [Claude Code](https://claude.com/claude-code)