### PR TITLE
fix: grant pull-requests: write to stale-issues workflow

### DIFF
--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -7,7 +7,7 @@ on:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run:


### PR DESCRIPTION
## Summary

- The reusable `gh-aw-stale-issues.lock.yml` workflow's nested jobs (`conclusion`, `safe_outputs`) require `pull-requests: write`, but the caller only granted `read`, causing the workflow to fail validation.
- Changed `pull-requests: read` → `pull-requests: write` in `stale-issues.yml`.

## Test plan

- [ ] Verify the workflow file passes GitHub Actions validation (no more "invalid workflow" error)
- [ ] Trigger `stale-issues.yml` via workflow_dispatch to confirm it runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)