### PR TITLE
Strengthen environment setup instructions in AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,15 +13,24 @@ Persist outcomes through safe outputs (comments/issues/PRs), because uncaptured 
 
 See ./peek
 
+## Environment Setup
+
+**Before running any build, lint, or test command**, you must install dependencies. This is a Node.js project — nothing works without `node_modules`.
+
+```bash
+cd peek && npm ci   # install dependencies from lockfile (fast, deterministic)
+```
+
+Always run this first. Do not use `npm install` — use `npm ci` which is faster in CI because it skips dependency resolution and installs exactly what the lockfile specifies.
+
 ## Common Commands
 
 ```bash
-make setup   # install dependencies
-make serve   # start dev server
-make build   # production build
 make lint    # Prettier + ESLint + TypeScript type checking
+make build   # production build (runs tsc + vite build)
+make serve   # start dev server
 make format  # auto-format code with Prettier
-make check   # run all checks then build (equivalent to CI)
+make check   # lint + unit tests + build (equivalent to CI)
 ```
 
 ## Playwright (Screenshots & E2E Testing)


### PR DESCRIPTION
## Summary

- Add an explicit **Environment Setup** section to `AGENTS.md` telling agents to run `cd peek && npm ci` before any build/lint/test command
- Reorder common commands to put `make lint` and `make build` first (what agents actually need) instead of `make setup`
- Remove `make setup` from the commands list — agents should use `npm ci` directly

## Why

Agents were wasting ~1-2 minutes per run discovering that dependencies weren't installed, failing on `make lint`, then figuring out they need `make setup` (which runs the slower `npm install`). The existing AGENTS.md listed `make setup` but didn't make it clear it was a prerequisite — it was just one command in a list.

## Test plan

- [ ] Verify the next agent run that needs lint/build installs deps with `npm ci` on first attempt

🤖 Generated with [Claude Code](https://claude.com/claude-code)