### PR TITLE
docs: add failure-handling rules for exploratory testing agents

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -329,6 +329,23 @@ They do NOT run pre-written test suites — deterministic E2E tests run in CI.
 Each agent writes and runs its own Playwright scripts to navigate, click, type,
 and inspect. They report only genuine bugs found through hands-on exploration.
 
+#### Handling failures during exploration
+
+When a Playwright interaction fails (timeout, element not found, unexpected state):
+
+1. **Do not retry the same action more than twice.** If it fails twice, the page
+   state is different from what you expected — retrying won't help.
+2. **Diagnose before moving on.** Take a screenshot at the point of failure.
+   Inspect the DOM to see what's actually on the page. Check if the element
+   exists with a different selector, or if the UI is in an unexpected state.
+3. **Adapt or report.** Either work around the failure (try a different selector,
+   a different interaction path, or skip to the next scenario) or report the
+   failure as a finding — a persistent timeout on an expected UI element is
+   itself a potential bug worth filing.
+4. **Never claim you verified something you didn't.** If a scenario failed and
+   you skipped it, say so in your output. Do not list it as "verified" or
+   "no issues found."
+
 ### Testing Philosophy
 
 - **Test behavior, not implementation** — assert on what the user sees and what the system does, not internal wiring.


### PR DESCRIPTION
## Summary

- Adds 4 failure-handling rules to the Exploratory Testing Agents section of `DEVELOPING.md`
- All explore agents inherit this guidance automatically

## Why

Observed the Metrics & Charts explore agent ([run 22534532470](https://github.com/elastic/ai-github-actions-playground/actions/runs/22534532470)) retry a single failing Playwright selector 14 times, waste 80% of its run in a retry loop, then call `noop` claiming "no reproducible defects" — despite never completing 4 of its 5 planned scenarios.

## Rules added

1. **Two strikes, stop retrying** — if an interaction fails twice, the page state is different from expected
2. **Diagnose before moving on** — screenshot + DOM inspection at the failure point
3. **Adapt or report** — try a different approach, or file the persistent failure as a finding
4. **Don't claim you verified something you skipped** — if a scenario failed, say so

## Test plan

- [ ] Verify `DEVELOPING.md` renders correctly in GitHub markdown preview
- [ ] Next explore agent run should diagnose failures instead of looping

🤖 Generated with [Claude Code](https://claude.com/claude-code)