### PR TITLE
fix: persist Query Lab query and results across navigation

### DIFF
--- a/peek/src/components/DiscoverPage.tsx
+++ b/peek/src/components/DiscoverPage.tsx
@@ -59,15 +59,31 @@ export default function DiscoverPage() {
   const addPanel = useDashboardStore((s) => s.addPanel);
   const activeDashboardId = useDashboardStore((s) => s.activeDashboardId);
   const setEditingPanelId = useUIStore((s) => s.setEditingPanelId);
-  const { discoverQueryDraft, setDiscoverQueryDraft, queryHistory, appendQueryToHistory } =
-    useQueryStore(
-      useShallow((s) => ({
-        discoverQueryDraft: s.discoverQueryDraft,
-        setDiscoverQueryDraft: s.setDiscoverQueryDraft,
-        queryHistory: s.queryHistory,
-        appendQueryToHistory: s.appendQueryToHistory,
-      })),
-    );
+  const {
+    discoverQueryDraft,
+    setDiscoverQueryDraft,
+    queryHistory,
+    appendQueryToHistory,
+    query,
+    setQuery,
+    result,
+    setResult,
+    selectedFields,
+    setSelectedFields,
+  } = useQueryStore(
+    useShallow((s) => ({
+      discoverQueryDraft: s.discoverQueryDraft,
+      setDiscoverQueryDraft: s.setDiscoverQueryDraft,
+      queryHistory: s.queryHistory,
+      appendQueryToHistory: s.appendQueryToHistory,
+      query: s.discoverQuery,
+      setQuery: s.setDiscoverQuery,
+      result: s.discoverResult,
+      setResult: s.setDiscoverResult,
+      selectedFields: s.discoverSelectedFields,
+      setSelectedFields: s.setDiscoverSelectedFields,
+    })),
+  );
   const refreshInterval = useDashboardStore(
     (s) => s.dashboard.refreshInterval ?? DEFAULT_REFRESH_INTERVAL,
   );
@@ -76,9 +92,8 @@ export default function DiscoverPage() {
   const navigate = useNavigate();
   const [queryContextView, setQueryContextView] = useState<EditorView | null>(null);
 
-  const [query, setQuery] = useState("FROM logs-* | SORT @timestamp | LIMIT 50");
-  const [result, setResult] = useState<EsqlResponse | null>(null);
-  const [selectedFields, setSelectedFields] = useState<Set<string>>(new Set());
+  // query, result, and selectedFields are now sourced from useQueryStore
+  // so they survive navigation (unmount/remount).
   const [fieldFilter, setFieldFilter] = useState("");
   const [tableVersion, setTableVersion] = useState(0);
   const [historyAnchor, setHistoryAnchor] = useState<HTMLElement | null>(null);
@@ -186,7 +201,7 @@ export default function DiscoverPage() {
       setExpandedInsight(null);
       insightQueryToColumnRef.current.clear();
     },
-    [discoverQueryDraft, setDiscoverQueryDraft, clearTimings],
+    [discoverQueryDraft, setDiscoverQueryDraft, clearTimings, setQuery],
   );
   const handleFormatQuery = useCallback(() => {
     handleQueryChange(formatEsqlQuery(effectiveQuery));
@@ -219,7 +234,7 @@ export default function DiscoverPage() {
       setQuery(newQuery);
       void runQuery(newQuery);
     },
-    [effectiveQuery, discoverQueryDraft, setDiscoverQueryDraft, runQuery],
+    [effectiveQuery, discoverQueryDraft, setDiscoverQueryDraft, setQuery, runQuery],
   );
   const handleSelectHistory = useCallback(
     (selectedQuery: string) => {
@@ -228,7 +243,7 @@ export default function DiscoverPage() {
       setQuery(selectedQuery);
       setHistoryAnchor(null);
     },
-    [setDiscoverQueryDraft, clearTimings],
+    [setDiscoverQueryDraft, clearTimings, setQuery],
   );
   const handleRunQueryRef = useRef(handleRunQuery);
   useEffect(() => {
@@ -256,18 +271,19 @@ export default function DiscoverPage() {
     return () => clearInterval(id);
   }, [connection, refreshInterval, effectiveQuery, loading, handleRunQuery]);
 
-  const toggleField = useCallback((name: string) => {
-    setSelectedFields((prev) => {
-      const next = new Set(prev);
+  const toggleField = useCallback(
+    (name: string) => {
+      const next = new Set(selectedFields);
       if (next.has(name)) {
         next.delete(name);
       } else {
         next.add(name);
       }
-      return next;
-    });
-    setTableVersion((prev) => prev + 1);
-  }, []);
+      setSelectedFields(next);
+      setTableVersion((prev) => prev + 1);
+    },
+    [selectedFields, setSelectedFields],
+  );
 
   const handleCreatePanel = useCallback(() => {
     const newPanel = {
@@ -306,22 +322,18 @@ export default function DiscoverPage() {
   );
 
   const selectVisibleFields = useCallback(() => {
-    setSelectedFields((prev) => {
-      const next = new Set(prev);
-      for (const col of visibleColumns) next.add(col.name);
-      return next;
-    });
+    const next = new Set(selectedFields);
+    for (const col of visibleColumns) next.add(col.name);
+    setSelectedFields(next);
     setTableVersion((prev) => prev + 1);
-  }, [visibleColumns]);
+  }, [selectedFields, setSelectedFields, visibleColumns]);
 
   const deselectVisibleFields = useCallback(() => {
-    setSelectedFields((prev) => {
-      const next = new Set(prev);
-      for (const col of visibleColumns) next.delete(col.name);
-      return next;
-    });
+    const next = new Set(selectedFields);
+    for (const col of visibleColumns) next.delete(col.name);
+    setSelectedFields(next);
     setTableVersion((prev) => prev + 1);
-  }, [visibleColumns]);
+  }, [selectedFields, setSelectedFields, visibleColumns]);
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%", gap: 1 }}>

--- a/peek/src/store/useQueryStore.ts
+++ b/peek/src/store/useQueryStore.ts
@@ -1,23 +1,42 @@
 import { create } from "zustand";
 import { persist } from "zustand/middleware";
 
+import type { EsqlResponse } from "../types";
+
+const DEFAULT_DISCOVER_QUERY = "FROM logs-* | SORT @timestamp | LIMIT 50";
+
 interface QueryState {
   discoverQueryDraft: string | null;
   queryHistory: string[];
 
+  /** The current ES|QL query text in the Query Lab editor. */
+  discoverQuery: string;
+  /** The last successful query result (session-only, not persisted to localStorage). */
+  discoverResult: EsqlResponse | null;
+  /** The set of field names selected for display in the results table. */
+  discoverSelectedFields: Set<string>;
+
   setDiscoverQueryDraft: (query: string | null) => void;
   appendQueryToHistory: (query: string) => void;
+  setDiscoverQuery: (query: string) => void;
+  setDiscoverResult: (result: EsqlResponse | null) => void;
+  setDiscoverSelectedFields: (fields: Set<string>) => void;
   resetQueryState: () => void;
 }
 
 const STORE_NAME = "elastic-peek-query";
 const QUERY_HISTORY_MAX_SIZE = 10;
 
+export { DEFAULT_DISCOVER_QUERY };
+
 export const useQueryStore = create<QueryState>()(
   persist(
     (set) => ({
       discoverQueryDraft: null,
       queryHistory: [],
+      discoverQuery: DEFAULT_DISCOVER_QUERY,
+      discoverResult: null,
+      discoverSelectedFields: new Set<string>(),
 
       setDiscoverQueryDraft: (query) => set({ discoverQueryDraft: query }),
       appendQueryToHistory: (query) =>
@@ -31,9 +50,18 @@ export const useQueryStore = create<QueryState>()(
             queryHistory: [trimmedQuery, ...dedupedHistory].slice(0, QUERY_HISTORY_MAX_SIZE),
           };
         }),
+      setDiscoverQuery: (query) => set({ discoverQuery: query }),
+      setDiscoverResult: (result) => set({ discoverResult: result }),
+      setDiscoverSelectedFields: (fields) => set({ discoverSelectedFields: fields }),
       resetQueryState: () => {
         useQueryStore.persist.clearStorage();
-        set({ discoverQueryDraft: null, queryHistory: [] });
+        set({
+          discoverQueryDraft: null,
+          queryHistory: [],
+          discoverQuery: DEFAULT_DISCOVER_QUERY,
+          discoverResult: null,
+          discoverSelectedFields: new Set<string>(),
+        });
       },
     }),
     {


### PR DESCRIPTION
## Summary

- Moves `query`, `result`, and `selectedFields` state from local `useState` in `DiscoverPage` to `useQueryStore`, so these values survive unmount/remount when navigating between Query Lab and other pages (e.g. Console)
- Adds `discoverQuery`, `discoverResult`, and `discoverSelectedFields` to the existing `useQueryStore` Zustand store, following the same pattern used by `useApiConsoleStore`
- Only `queryHistory` is persisted to localStorage (via `partialize`); the new fields are session-only memory state that survives route changes but not page reloads

Closes #927

## Test plan

- [ ] Open Query Lab, enter and run an ES|QL query, verify results appear
- [ ] Navigate to Console, then back to Query Lab -- query text and results should still be visible
- [ ] Run a different query, navigate away and back -- new query and results should persist
- [ ] Verify "Reset All" still clears Query Lab state (resetQueryState resets the new fields)
- [ ] Verify field picker select/deselect all still works correctly
- [ ] TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] ESLint passes on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)