### PR TITLE
feat: switch explore workflows from Copilot to Gemini CLI

### DIFF
--- a/.github/workflows/explore-connection.yml
+++ b/.github/workflows/explore-connection.yml
@@ -7,14 +7,14 @@ on:
 permissions:
   actions: read
   contents: read
+  discussions: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-scheduled-audit.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      title-prefix: "[explore-connection]"
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium
@@ -91,5 +91,7 @@ jobs:
         - If everything works, do **not** open an issue.
         - If you find problems, create **one** issue describing what you
           tried, what you expected, what actually happened, and screenshots.
+        - When creating an issue, prefix the title with `[explore-connection]`
+          (after the automatically added `[gemini-cli]` prefix).
     secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-customer-feedback.yml
+++ b/.github/workflows/explore-customer-feedback.yml
@@ -7,14 +7,14 @@ on:
 permissions:
   actions: read
   contents: read
+  discussions: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-scheduled-audit.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      title-prefix: "[customer-feedback]"
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium
@@ -117,5 +117,7 @@ jobs:
           gaps are both fair game.
         - If you genuinely can't find any gaps (unlikely), do not open
           an issue.
+        - When creating an issue, prefix the title with `[customer-feedback]`
+          (after the automatically added `[gemini-cli]` prefix).
     secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-data-management.yml
+++ b/.github/workflows/explore-data-management.yml
@@ -7,14 +7,14 @@ on:
 permissions:
   actions: read
   contents: read
+  discussions: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-scheduled-audit.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      title-prefix: "[explore-data-management]"
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium
@@ -97,5 +97,7 @@ jobs:
         - If everything works, do **not** open an issue.
         - If you find problems, create **one** issue describing what you
           tried, what you expected, what actually happened, and screenshots.
+        - When creating an issue, prefix the title with `[explore-data-management]`
+          (after the automatically added `[gemini-cli]` prefix).
     secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-live-es.yml
+++ b/.github/workflows/explore-live-es.yml
@@ -7,14 +7,14 @@ on:
 permissions:
   actions: read
   contents: read
+  discussions: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-scheduled-audit.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      title-prefix: "[explore-live-es]"
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium
@@ -135,5 +135,7 @@ jobs:
         - If everything works, do **not** open an issue.
         - If you find problems, create **one** issue describing what you
           tried, what you expected, what actually happened, and screenshots.
+        - When creating an issue, prefix the title with `[explore-live-es]`
+          (after the automatically added `[gemini-cli]` prefix).
     secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-metrics.yml
+++ b/.github/workflows/explore-metrics.yml
@@ -7,14 +7,14 @@ on:
 permissions:
   actions: read
   contents: read
+  discussions: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-scheduled-audit.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      title-prefix: "[explore-metrics]"
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium
@@ -95,5 +95,7 @@ jobs:
         - If everything works, do **not** open an issue.
         - If you find problems, create **one** issue describing what you
           tried, what you expected, what actually happened, and screenshots.
+        - When creating an issue, prefix the title with `[explore-metrics]`
+          (after the automatically added `[gemini-cli]` prefix).
     secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-query-lab.yml
+++ b/.github/workflows/explore-query-lab.yml
@@ -7,14 +7,14 @@ on:
 permissions:
   actions: read
   contents: read
+  discussions: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-scheduled-audit.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      title-prefix: "[explore-query-lab]"
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium
@@ -99,5 +99,7 @@ jobs:
         - If everything works, do **not** open an issue.
         - If you find problems, create **one** issue describing what you
           tried, what you expected, what actually happened, and screenshots.
+        - When creating an issue, prefix the title with `[explore-query-lab]`
+          (after the automatically added `[gemini-cli]` prefix).
     secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-traces.yml
+++ b/.github/workflows/explore-traces.yml
@@ -7,14 +7,14 @@ on:
 permissions:
   actions: read
   contents: read
+  discussions: write
   issues: write
-  pull-requests: read
+  pull-requests: write
 
 jobs:
   run:
-    uses: elastic/ai-github-actions/.github/workflows/gh-aw-scheduled-audit.lock.yml@main
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      title-prefix: "[explore-traces]"
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium
@@ -102,5 +102,7 @@ jobs:
         - If everything works, do **not** open an issue.
         - If you find problems, create **one** issue describing what you
           tried, what you expected, what actually happened, and screenshots.
+        - When creating an issue, prefix the title with `[explore-traces]`
+          (after the automatically added `[gemini-cli]` prefix).
     secrets:
-      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,7 +135,7 @@ ES_URL=http://localhost:9200 make serve-proxy
 # Then open http://localhost:3000 and connect to http://localhost:3000/_es
 ```
 
-This is the same data the `smoke-live-es.yml` agent explores against.
+This is the same data the `explore-live-es.yml` agent explores against.
 Use `make otel-replay-down` to tear everything down when done.
 
 ### Exploratory Testing Agents
@@ -144,13 +144,13 @@ Eight scheduled agents creatively explore the app with Playwright. Each owns a
 domain and invents novel interaction scenarios every run — they do NOT run
 pre-written test suites. Deterministic E2E tests run in CI instead.
 
-- `smoke-welcome-flow.yml` → **Explore: Connection & Onboarding** — connection dialog, auth tabs, disconnect/reconnect, keyboard nav
-- `smoke-metrics-flow.yml` → **Explore: Metrics & Charts** — metric search, chart rendering, time ranges, state persistence
-- `smoke-traces-flow.yml` → **Explore: Traces & Service Map** — span trees, service map, trace-to-query pivot, navigation
-- `smoke-auth-tab-switch.yml` → **Explore: Query Lab & Console** — ES|QL queries, result tables, API Console, error handling
-- `smoke-reset-visibility.yml` → **Explore: Indices, Data Streams & Pipelines** — table sorting, detail views, data management
-- `smoke-live-es.yml` → **Explore: Live Elasticsearch** — real OTel data, full stack, all pages with real cluster
-- `customer-complaints.yml` → **Customer: Feature Gap Review** — missing features, feature requests, comparison to Kibana/Grafana/Elasticvue
+- `explore-connection.yml` → **Explore: Connection & Onboarding** — connection dialog, auth tabs, disconnect/reconnect, keyboard nav
+- `explore-metrics.yml` → **Explore: Metrics & Charts** — metric search, chart rendering, time ranges, state persistence
+- `explore-traces.yml` → **Explore: Traces & Service Map** — span trees, service map, trace-to-query pivot, navigation
+- `explore-query-lab.yml` → **Explore: Query Lab & Console** — ES|QL queries, result tables, API Console, error handling
+- `explore-data-management.yml` → **Explore: Indices, Data Streams & Pipelines** — table sorting, detail views, data management
+- `explore-live-es.yml` → **Explore: Live Elasticsearch** — real OTel data, full stack, all pages with real cluster
+- `explore-customer-feedback.yml` → **Customer: Feature Gap Review** — missing features, feature requests, comparison to Kibana/Grafana/Elasticvue
 - `ui-designer-review.yml` → **Design: Modern UI Review** — design modernization, spacing, typography, cards, tables, empty states, loading patterns
 
 ### Visual Quality Checklist

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -341,13 +341,13 @@ They do NOT run pre-written test suites — deterministic E2E tests run in CI.
 
 | Agent | Domain | Workflow |
 | --- | --- | --- |
-| Connection & Onboarding | Connection dialog, auth tabs, disconnect/reconnect | `smoke-welcome-flow.yml` |
-| Metrics & Charts | Metric search, chart rendering, time ranges | `smoke-metrics-flow.yml` |
-| Traces & Service Map | Span trees, service map, trace-to-query pivot | `smoke-traces-flow.yml` |
-| Query Lab & Console | ES\|QL queries, result tables, API Console | `smoke-auth-tab-switch.yml` |
-| Indices, Data Streams & Pipelines | Table sorting, detail views, data management | `smoke-reset-visibility.yml` |
-| Live Elasticsearch | All pages with real OTel data and a real cluster | `smoke-live-es.yml` |
-| Customer: Feature Gap Review | Missing features, feature requests, comparison to Kibana/Grafana/Elasticvue | `customer-complaints.yml` |
+| Connection & Onboarding | Connection dialog, auth tabs, disconnect/reconnect | `explore-connection.yml` |
+| Metrics & Charts | Metric search, chart rendering, time ranges | `explore-metrics.yml` |
+| Traces & Service Map | Span trees, service map, trace-to-query pivot | `explore-traces.yml` |
+| Query Lab & Console | ES\|QL queries, result tables, API Console | `explore-query-lab.yml` |
+| Indices, Data Streams & Pipelines | Table sorting, detail views, data management | `explore-data-management.yml` |
+| Live Elasticsearch | All pages with real OTel data and a real cluster | `explore-live-es.yml` |
+| Customer: Feature Gap Review | Missing features, feature requests, comparison to Kibana/Grafana/Elasticvue | `explore-customer-feedback.yml` |
 | Design: Modern UI Review | Design modernization, spacing, typography, cards, tables, empty states, loading patterns | `ui-designer-review.yml` |
 
 Each agent writes and runs its own Playwright scripts to navigate, click, type,

--- a/docs/agent-dossier.md
+++ b/docs/agent-dossier.md
@@ -464,16 +464,16 @@ Eight Playwright-powered exploratory agents run on weekdays. Each owns a domain 
 
 | Agent | File | Schedule | Domain |
 |-------|------|----------|--------|
-| **Connection & Onboarding** | `smoke-welcome-flow.yml` | 09:00 UTC | Connection dialog, auth tabs, disconnect/reconnect, keyboard nav |
-| **Metrics & Charts** | `smoke-metrics-flow.yml` | 10:00 UTC | Metric search, chart rendering, time ranges, state persistence |
-| **Traces & Service Map** | `smoke-traces-flow.yml` | 11:00 UTC | Span trees, service map, trace-to-query pivot, navigation |
-| **Query Lab & Console** | `smoke-auth-tab-switch.yml` | 12:00 UTC | ES\|QL queries, result tables, API Console, error handling |
-| **Indices, Data Streams & Pipelines** | `smoke-reset-visibility.yml` | 13:00 UTC | Table sorting, detail views, data management |
-| **Live Elasticsearch** | `smoke-live-es.yml` | 14:00 UTC | All pages with real OTel data and a real cluster |
-| **Feature Gap Review** | `customer-complaints.yml` | 16:00 UTC | Missing features vs Kibana/Grafana/Elasticvue expectations |
+| **Connection & Onboarding** | `explore-connection.yml` | 09:00 UTC | Connection dialog, auth tabs, disconnect/reconnect, keyboard nav |
+| **Metrics & Charts** | `explore-metrics.yml` | 10:00 UTC | Metric search, chart rendering, time ranges, state persistence |
+| **Traces & Service Map** | `explore-traces.yml` | 11:00 UTC | Span trees, service map, trace-to-query pivot, navigation |
+| **Query Lab & Console** | `explore-query-lab.yml` | 12:00 UTC | ES\|QL queries, result tables, API Console, error handling |
+| **Indices, Data Streams & Pipelines** | `explore-data-management.yml` | 13:00 UTC | Table sorting, detail views, data management |
+| **Live Elasticsearch** | `explore-live-es.yml` | 14:00 UTC | All pages with real OTel data and a real cluster |
+| **Feature Gap Review** | `explore-customer-feedback.yml` | 16:00 UTC | Missing features vs Kibana/Grafana/Elasticvue expectations |
 | **Modern UI Review** | `ui-designer-review.yml` | 17:00 UTC | Design modernization vs Linear/Vercel/Stripe standards |
 
-All exploratory agents use `gh-aw-scheduled-audit.lock.yml` with creative Playwright exploration instructions.
+Exploratory agents use `gh-aw-internal-gemini-cli.lock.yml` (Gemini) with creative Playwright exploration instructions. The Modern UI Review agent uses `gh-aw-scheduled-audit.lock.yml` (Copilot).
 
 ### Give It Some Love
 

--- a/scripts/run-smoke-detectors.sh
+++ b/scripts/run-smoke-detectors.sh
@@ -42,13 +42,13 @@ fi
 
 # Explore agent workflows that support workflow_dispatch
 WORKFLOWS=(
-  "smoke-welcome-flow.yml"
-  "smoke-metrics-flow.yml"
-  "smoke-traces-flow.yml"
-  "smoke-auth-tab-switch.yml"
-  "smoke-reset-visibility.yml"
-  "smoke-live-es.yml"
-  "customer-complaints.yml"
+  "explore-connection.yml"
+  "explore-metrics.yml"
+  "explore-traces.yml"
+  "explore-query-lab.yml"
+  "explore-data-management.yml"
+  "explore-live-es.yml"
+  "explore-customer-feedback.yml"
   "ui-designer-review.yml"
 )
 


### PR DESCRIPTION
## Summary

- Renames 7 `smoke-*`/`customer-complaints` workflow files to `explore-*` for consistency
- Switches from `gh-aw-scheduled-audit.lock.yml` (Copilot) to `gh-aw-internal-gemini-cli.lock.yml` (Gemini CLI)
- Gemini is multimodal — agents can now visually analyze screenshots during exploratory testing
- Updates permissions (`+discussions:write`, `pull-requests: write`), secret (`GEMINI_API_KEY`), and documentation

### File rename mapping

| Old | New |
|-----|-----|
| `smoke-welcome-flow.yml` | `explore-connection.yml` |
| `smoke-metrics-flow.yml` | `explore-metrics.yml` |
| `smoke-traces-flow.yml` | `explore-traces.yml` |
| `smoke-auth-tab-switch.yml` | `explore-query-lab.yml` |
| `smoke-reset-visibility.yml` | `explore-data-management.yml` |
| `smoke-live-es.yml` | `explore-live-es.yml` |
| `customer-complaints.yml` | `explore-customer-feedback.yml` |

## Test plan

- [ ] Verify YAML validity (all 7 files pass `js-yaml` parsing)
- [ ] No stale references to old filenames in docs/scripts
- [ ] `GEMINI_API_KEY` secret exists in repo settings
- [ ] Trigger one workflow via `workflow_dispatch` to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)