### PR TITLE
fix: global unit test environment and refine AI assistant drawer UI

### DIFF
--- a/peek/src/components/AiAssistantDrawer.tsx
+++ b/peek/src/components/AiAssistantDrawer.tsx
@@ -2,9 +2,12 @@ import Drawer from "@mui/material/Drawer";
 import Box from "@mui/material/Box";
 import Typography from "@mui/material/Typography";
 import IconButton from "@mui/material/IconButton";
+import Button from "@mui/material/Button";
 import CloseIcon from "@mui/icons-material/Close";
+import DeleteOutlineIcon from "@mui/icons-material/DeleteOutline";
 
 import { useUIStore } from "../store/useUIStore";
+import { useLLMStore } from "../store/useLLMStore";
 
 import ChatPage from "./ChatPage";
 
@@ -13,6 +16,8 @@ const AI_DRAWER_WIDTH = 440;
 export default function AiAssistantDrawer() {
   const open = useUIStore((s) => s.aiPanelOpen);
   const setOpen = useUIStore((s) => s.setAiPanelOpen);
+  const clearMessages = useLLMStore((s) => s.clearMessages);
+  const hasMessages = useLLMStore((s) => s.messages.length > 0);
 
   return (
     <Drawer
@@ -38,10 +43,20 @@ export default function AiAssistantDrawer() {
           p: 2,
         }}
       >
-        <Box sx={{ display: "flex", alignItems: "center", mb: 1 }}>
+        <Box sx={{ display: "flex", alignItems: "center", mb: 1, gap: 1 }}>
           <Typography id="ai-drawer-title" variant="subtitle1" sx={{ flex: 1, fontWeight: 600 }}>
             AI Assistant
           </Typography>
+          <Button
+            size="small"
+            variant="text"
+            startIcon={<DeleteOutlineIcon />}
+            onClick={clearMessages}
+            disabled={!hasMessages}
+            sx={{ color: "text.secondary" }}
+          >
+            Clear
+          </Button>
           <IconButton
             size="small"
             onClick={() => setOpen(false)}
@@ -50,7 +65,7 @@ export default function AiAssistantDrawer() {
             <CloseIcon fontSize="small" />
           </IconButton>
         </Box>
-        <ChatPage />
+        <ChatPage hideHeader />
       </Box>
     </Drawer>
   );

--- a/peek/src/components/ChatPage.tsx
+++ b/peek/src/components/ChatPage.tsx
@@ -21,7 +21,7 @@ import { useConnectionStore } from "../store/useConnectionStore";
 import { buildChatRuntime, getChatRequestTimeoutMs } from "../services/chatRuntime";
 import { useChatScreenContextSummary } from "../hooks/useChatScreenContextSummary";
 
-export default function ChatPage() {
+export default function ChatPage({ hideHeader = false }: { hideHeader?: boolean }) {
   const {
     config,
     messages,
@@ -164,20 +164,22 @@ export default function ChatPage() {
 
   return (
     <Box sx={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}>
-      <Box sx={{ display: "flex", alignItems: "center", mb: 1, gap: 1 }}>
-        <Typography variant="h6" sx={{ flex: 1, fontWeight: 600 }}>
-          Chat
-        </Typography>
-        <Button
-          size="small"
-          variant="outlined"
-          startIcon={<DeleteOutlineIcon />}
-          onClick={clearMessages}
-          disabled={messages.length === 0}
-        >
-          Clear
-        </Button>
-      </Box>
+      {!hideHeader && (
+        <Box sx={{ display: "flex", alignItems: "center", mb: 1, gap: 1 }}>
+          <Typography variant="h6" sx={{ flex: 1, fontWeight: 600 }}>
+            Chat
+          </Typography>
+          <Button
+            size="small"
+            variant="outlined"
+            startIcon={<DeleteOutlineIcon />}
+            onClick={clearMessages}
+            disabled={messages.length === 0}
+          >
+            Clear
+          </Button>
+        </Box>
+      )}
 
       {error && (
         <Alert severity="error" onClose={() => setError(null)} sx={{ mb: 1 }}>


### PR DESCRIPTION
This PR refines the AI Assistant Drawer UI by moving the `Clear` action into the drawer header and updating `ChatPage` to support `hideHeader` so the embedded chat view avoids duplicate headers.

> Generated by [Update PR Body](https://github.com/elastic/ai-github-actions-playground/actions/runs/22538517140) for issue #1006

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22538517140, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions-playground/actions/runs/22538517140 -->