### PR TITLE
fix: pin explore workflows to gemini-3-pro

### DIFF
--- a/.github/workflows/explore-connection.yml
+++ b/.github/workflows/explore-connection.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      model: gemini-3-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium

--- a/.github/workflows/explore-customer-feedback.yml
+++ b/.github/workflows/explore-customer-feedback.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      model: gemini-3-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium

--- a/.github/workflows/explore-data-management.yml
+++ b/.github/workflows/explore-data-management.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      model: gemini-3-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium

--- a/.github/workflows/explore-live-es.yml
+++ b/.github/workflows/explore-live-es.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      model: gemini-3-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium

--- a/.github/workflows/explore-metrics.yml
+++ b/.github/workflows/explore-metrics.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      model: gemini-3-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium

--- a/.github/workflows/explore-query-lab.yml
+++ b/.github/workflows/explore-query-lab.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      model: gemini-3-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium

--- a/.github/workflows/explore-traces.yml
+++ b/.github/workflows/explore-traces.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      model: gemini-3-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium


### PR DESCRIPTION
## Summary

- Pins all 7 explore workflows to `gemini-3-pro` (GA) instead of the default `gemini-3-pro-preview`
- The preview model was hitting free-tier quota limits (`generate_content_free_tier_input_token_count`) even with a tier 3 API key
- See failed run: https://github.com/elastic/ai-github-actions-playground/actions/runs/22538047447

## Test plan

- [ ] Trigger one explore workflow via `workflow_dispatch` and confirm it completes without quota errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)