### PR TITLE
fix: pin explore workflows to latest stable gemini-3.1-pro-preview

### DIFF
--- a/.github/workflows/explore-connection.yml
+++ b/.github/workflows/explore-connection.yml
@@ -15,7 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      model: gemini-3-pro
+      model: gemini-3.1-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium

--- a/.github/workflows/explore-customer-feedback.yml
+++ b/.github/workflows/explore-customer-feedback.yml
@@ -15,7 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      model: gemini-3-pro
+      model: gemini-3.1-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium

--- a/.github/workflows/explore-data-management.yml
+++ b/.github/workflows/explore-data-management.yml
@@ -15,7 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      model: gemini-3-pro
+      model: gemini-3.1-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium

--- a/.github/workflows/explore-live-es.yml
+++ b/.github/workflows/explore-live-es.yml
@@ -15,7 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      model: gemini-3-pro
+      model: gemini-3.1-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium

--- a/.github/workflows/explore-metrics.yml
+++ b/.github/workflows/explore-metrics.yml
@@ -15,7 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      model: gemini-3-pro
+      model: gemini-3.1-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium

--- a/.github/workflows/explore-query-lab.yml
+++ b/.github/workflows/explore-query-lab.yml
@@ -15,7 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      model: gemini-3-pro
+      model: gemini-3.1-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium

--- a/.github/workflows/explore-traces.yml
+++ b/.github/workflows/explore-traces.yml
@@ -15,7 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
-      model: gemini-3-pro
+      model: gemini-3.1-pro
       setup-commands: |
         make setup
         cd peek && npx playwright install chromium


### PR DESCRIPTION
This PR updates the pinned model in the explore workflows to  (released February 19, 2026). The previous pinning to  was invalid and causing 'model not found' errors. This also moves away from the deprecated  which is scheduled for shutdown on March 9, 2026.