### PR TITLE
docs: deduplicate and tighten project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,18 @@ make check   # lint + unit tests + build (equivalent to CI)
 ## Playwright (Screenshots & E2E Testing)
 
 Playwright is available for navigating the app, taking screenshots, and capturing console errors.
+
+### Interactive Browser Automation (MCP Tools)
+
+Exploratory testing agents use **Playwright MCP tools** for interactive browser
+automation. This is configured via `.gemini/settings.json` and provides tools
+like `browser_navigate`, `browser_click`, `browser_type`, `browser_snapshot`,
+and `browser_take_screenshot`.
+
+**Do NOT write Node.js scripts to drive the browser** — use the MCP tools
+directly for step-by-step interactive exploration. This allows you to see
+the page state after each action and adapt based on what you find.
+
 After `make setup`, install the Chromium browser binary:
 
 ```bash
@@ -105,9 +117,7 @@ The Playwright config (`peek/playwright.config.ts`) auto-starts the Vite dev ser
 
 ### Verifying Changes Against Real Elasticsearch Data
 
-When implementing features or fixing bugs, you can verify your changes render
-correctly against real OTel data (traces, metrics, logs) instead of just mocks.
-This catches issues that only appear with real-world data shapes and volumes.
+See DEVELOPING.md § OTLP Fixture Capture & Replay for full replay commands, data tables, and teardown instructions.
 
 **Quick start (one-liner):**
 
@@ -118,40 +128,9 @@ make otel-replay-up && make otel-replay && make test-e2e-live
 make otel-replay-down
 ```
 
-**What this gives you:**
-
-| Data | Source | Indices created |
-|------|--------|----------------|
-| Traces (9-service distributed) | OTLP fixture replay | `traces-generic.otel-default` |
-| Metrics (CPU, memory, disk) | OTLP fixture replay | `metrics-hostmetricsreceiver.otel-default` |
-| Logs | OTLP fixture replay | `logs-generic.otel-default` |
-| web_logs, orders | `seed-elasticsearch.mjs` | `web_logs`, `orders` |
-| Ingest pipelines | `seed-elasticsearch.mjs` | `logs-parse-nginx`, `enrich-geoip`, `metrics-normalize` |
-
-After replay, connect the dev server to the live cluster:
-
-```bash
-ES_URL=http://localhost:9200 make serve-proxy
-# Then open http://localhost:3000 and connect to http://localhost:3000/_es
-```
-
-This is the same data the `explore-live-es.yml` agent explores against.
-Use `make otel-replay-down` to tear everything down when done.
-
 ### Exploratory Testing Agents
 
-Eight scheduled agents creatively explore the app with Playwright. Each owns a
-domain and invents novel interaction scenarios every run — they do NOT run
-pre-written test suites. Deterministic E2E tests run in CI instead.
-
-- `explore-connection.yml` → **Explore: Connection & Onboarding** — connection dialog, auth tabs, disconnect/reconnect, keyboard nav
-- `explore-metrics.yml` → **Explore: Metrics & Charts** — metric search, chart rendering, time ranges, state persistence
-- `explore-traces.yml` → **Explore: Traces & Service Map** — span trees, service map, trace-to-query pivot, navigation
-- `explore-query-lab.yml` → **Explore: Query Lab & Console** — ES|QL queries, result tables, API Console, error handling
-- `explore-data-management.yml` → **Explore: Indices, Data Streams & Pipelines** — table sorting, detail views, data management
-- `explore-live-es.yml` → **Explore: Live Elasticsearch** — real OTel data, full stack, all pages with real cluster
-- `explore-customer-feedback.yml` → **Customer: Feature Gap Review** — missing features, feature requests, comparison to Kibana/Grafana/Elasticvue
-- `ui-designer-review.yml` → **Design: Modern UI Review** — design modernization, spacing, typography, cards, tables, empty states, loading patterns
+See DEVELOPING.md § Exploratory Testing Agents for the full agent list, domains, and failure-handling rules.
 
 ### Visual Quality Checklist
 
@@ -159,32 +138,28 @@ Every exploratory agent MUST check these visual quality dimensions on pages
 it visits. These are the exact defect patterns found in the February 2026
 full-app audit (issue #872).
 
-**Element height consistency in toolbars** — All interactive controls in a
-filter/toolbar row (text fields, selects, chips, buttons) must be the same
-height. A mismatch of more than 4px is a bug. Measure programmatically:
+**Element height consistency in toolbars** — See DESIGN_LANGUAGE.md § Component Heights — a mismatch >4px is a bug. Measure using `browser_console_execute`:
 
 ```javascript
-const heights = await page.evaluate(() => {
+(() => {
   const els = document.querySelectorAll('input, button, [role="combobox"], [role="button"]');
-  return Array.from(els)
+  return JSON.stringify(Array.from(els)
     .map(el => {
       const r = el.getBoundingClientRect();
       return { tag: el.tagName, h: Math.round(r.height), top: Math.round(r.top), text: el.textContent?.trim().slice(0, 20) };
     })
-    .filter(el => el.top > 50 && el.top < 250);
-});
+    .filter(el => el.top > 50 && el.top < 250));
+})()
 ```
 
-**text.secondary contrast on dark mode** — Elements using MUI
-`color="text.secondary"` on dark backgrounds can fall below WCAG AA 4.5:1.
+**text.secondary contrast on dark mode** — See DESIGN_LANGUAGE.md § Brand Palette for the `text.secondary` minimum.
 Check: sidebar section headers ("WORKSPACE", "SYSTEM", "HELP"), metric card
 subtitle labels, table column headers, empty state helper text, and fieldset
 `<legend>` elements. Switch to dark mode via Settings gear and take a
 screenshot.
 
-**Empty state consistency** — Every page that can show "no data" must display
-a centered icon, a short bold title, and a one-line helper sentence. No page
-should show a blank rectangle. Pages to verify: Query Lab, Metrics, Traces,
+**Empty state consistency** — See DESIGN_LANGUAGE.md § Empty States for required anatomy.
+Pages to verify: Query Lab, Metrics, Traces,
 Dashboards, Fleet, Indices, Ingest Pipelines.
 
 **Fieldset and legend visibility** — MUI `<fieldset>` borders with `<legend>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,31 +24,7 @@ Before filing an issue, use an AI assistant to research the problem or feature. 
 
 ### 2. Open an Issue with a Plan
 
-Create an issue with a clear, step-by-step implementation plan. The more detailed your plan, the better the agent can execute it.
-
-**Example:**
-
-```markdown
-## Add heatmap visualization type
-
-### Analysis
-The dashboard currently supports time series, bar, pie, table, stat, and gauge
-visualizations. A heatmap would be useful for visualizing density distributions
-from ES|QL aggregations like STATS ... BY bucket1, bucket2.
-
-### Implementation Plan
-
-1. **Create HeatmapChart component** (`peek/src/components/visualizations/HeatmapChart.tsx`):
-   - Accept EsqlResponse data
-   - Map two categorical columns to x/y axes and a numeric column to color intensity
-   - Use ECharts heatmap series type
-
-2. **Register the visualization**:
-   - Add "heatmap" to `VISUALIZATION_TYPES` and `vizRegistryEntries` in `peek/src/components/visualizations/vizRegistry.tsx`
-
-3. **Verify**:
-   - Run `make check` to run lint, unit tests, and build
-```
+Create an issue with: analysis of the problem/feature, step-by-step implementation plan naming specific files and components, and verification steps (`make check`).
 
 ### 3. Maintainer Assigns an Agent
 

--- a/DESIGN_LANGUAGE.md
+++ b/DESIGN_LANGUAGE.md
@@ -1,0 +1,361 @@
+# Elastic Peek Design Language
+
+The canonical visual and interaction specification for Elastic Peek. AI agents and humans building UI for this project treat this document as the single authority on how things look, feel, and behave. Engineering standards (file structure, state management, testing) live in DEVELOPING.md — this document covers only design decisions.
+
+---
+
+## Identity
+
+Elastic Peek is a lightweight observability tool that connects directly to Elasticsearch. It is not Kibana, not Grafana, and not a general-purpose BI tool. It is a scalpel for engineers who think in ES|QL and want fast, clear answers from their data. Dashboards use the [Perses](https://perses.dev) data model and charting framework (CNCF project, ECharts-based).
+
+The design personality is **clinical precision with warmth**. Dense information, zero ambiguity, effortless scanning. The UI never decorates — every pixel earns its place by conveying data or enabling action. No drop shadows. No gradients. No decorative borders.
+
+---
+
+## Color System
+
+### Brand Palette
+
+Dark mode is the primary theme. Light mode is a first-class alternative, not an afterthought. Never use raw hex values in components — always reference theme tokens via the `sx` prop.
+
+```
+Token Name               Dark Mode       Light Mode
+──────────────────────── ─────────────── ───────────────
+background.default       #1D1E24         #F5F7FA
+background.paper         #25262E         #FFFFFF
+background.sunken        #16171C         #EDF0F5
+background.raised        #2D2E36         #FFFFFF
+text.primary             #DFE5EF         #1A1C21
+text.secondary           #98A2B3         #69707D
+text.disabled            #535966         #ABB4C4
+primary.main             #36A2EF         #0077CC
+primary.hover            #5AB4F5         #005FA3
+secondary.main           #7DE2D1         #00BFB3
+border.default           #343741         #D3DAE6
+border.strong            #535966         #98A7B9
+```
+
+The `text.secondary` value in dark mode is `#98A2B3` — 4.6:1 contrast against `#25262E` paper background, clearing WCAG AA. Never go darker than this for secondary text.
+
+### Status Colors
+
+Status always uses color + icon + text label. Never color alone.
+
+```
+Semantic Name     Dark Mode       Light Mode      MUI Icon
+──────────────── ─────────────── ─────────────── ──────────────
+status.healthy    #54B399         #00A676         CheckCircle
+status.warning    #F5A623         #D68000         Warning
+status.critical   #E7664C         #BD271E         Error
+status.unknown    #69707D         #98A7B9         HelpOutline
+status.info       #6092C0         #0077CC         Info
+```
+
+### Chart Series Palette
+
+Twelve colors in `CHART_COLORS` (defined in `theme.ts`), ordered for maximum adjacent contrast. CVD-safe for deuteranopia, protanopia, and tritanopia across adjacent pairs. These colors are fed to ECharts via `useEChartTheme()` and will be provided by Perses's `ChartsProvider` once the theming migration completes.
+
+```
+Index   Hex         Name
+──────  ─────────── ──────────
+0       #0077CC     Elastic Blue
+1       #00BFB3     Teal
+2       #BD271E     Red
+3       #F5A623     Amber
+4       #6092C0     Steel
+5       #D36086     Rose
+6       #9170B8     Violet
+7       #CA8EAE     Mauve
+8       #54B399     Sage
+9       #DA8B45     Copper
+10      #AA6556     Rust
+11      #E7664C     Coral
+```
+
+For charts with more than 8 series, enable hover-to-highlight and click-to-isolate. The palette degrades beyond 8 simultaneous on-screen colors.
+
+### Threshold Colors
+
+Three levels only. Applied via `resolveThresholdColor` in `thresholdUtils.ts`.
+
+```
+success     #54B399     Value is within normal range
+warning     #F5A623     Value needs attention
+error       #BD271E     Value is critical
+```
+
+---
+
+## Typography
+
+### Font Stack
+
+```css
+--font-sans: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+--font-mono: 'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+```
+
+Inter is loaded as a variable font. Tabular figures are enabled globally:
+
+```css
+body { font-variant-numeric: tabular-nums lining-nums; }
+```
+
+### Type Scale
+
+Four levels. Each maps to exactly one MUI Typography `variant`.
+
+```
+Role              MUI variant    Size    Weight    Line-Height   Use
+────────────────  ───────────    ──────  ────────  ────────────  ──────────────────────────
+Page Title        h5             20px    600       1.2           One per page, top-left
+Section Header    subtitle1      14px    600       1.3           Card titles, group labels
+Body              body1          14px    400       1.5           All prose and UI text
+Caption / Data    body2          12px    400       1.4           Table headers, axis labels
+```
+
+Only these four variants are permitted in page content. Do not introduce new uses of `h4`, `h6`, `subtitle2`, or `overline`.
+
+### Monospace Text
+
+Used for: ES|QL queries, log messages, field names, index names, span IDs, API responses, and any machine-generated string. Body size mono is 13px (compensating for JetBrains Mono's wider metrics).
+
+### Metric Display
+
+Large stat values (KPI cards, cluster overview):
+
+```
+Metric Value     h3             32px    700       1.1
+Metric Label     body2          12px    400       1.4           text.secondary color
+```
+
+`h3` is used exclusively for stat values — never for headings or section titles.
+
+---
+
+## Spacing
+
+Base unit: **4px**. All spacing values are multiples of 4.
+
+```
+Token       Value     MUI sx    Use
+──────────  ────────  ────────  ──────────────────────────────────
+space.0     0px       0         Reset
+space.1     4px       0.5       Tight inline gap (icon-to-text)
+space.2     8px       1         Default inline gap, chip padding
+space.3     12px      1.5       Input padding, compact card inset
+space.4     16px      2         Card padding, section gap
+space.5     20px      2.5       Comfortable card padding
+space.6     24px      3         Page-level section separation
+space.8     32px      4         Major section dividers
+space.12    48px      6         Empty state vertical padding
+```
+
+### Component Heights
+
+One density: **Compact**. Comfortable spacing is for empty states, welcome screens, and docs pages only.
+
+```
+Element              Height
+───────────────────  ────────
+Input / Select       36px
+Button (default)     36px
+Button (small)       28px
+Table row            36px
+Sidebar nav item     32px
+Toolbar row          44px (including 4px vertical padding)
+```
+
+All interactive elements in a toolbar row must be the same height. A mismatch greater than 4px is a bug.
+
+---
+
+## Layout
+
+### Page Structure
+
+```
+┌─────────────────────────────────────────────────────┐
+│  AppHeader (48px, fixed top)                        │
+├────────┬────────────────────────────────────────────┤
+│        │  PageHeader: Title + Actions (48px)        │
+│  Side  ├────────────────────────────────────────────┤
+│  bar   │  ToolBar: Filters, time range, search     │
+│  nav   ├────────────────────────────────────────────┤
+│        │                                            │
+│  68px  │  Content Area                              │
+│  or    │  (scrollable, flex-grow)                   │
+│  200px │                                            │
+│        │                                            │
+├────────┴────────────────────────────────────────────┤
+│  (no footer — status info goes in header or inline) │
+└─────────────────────────────────────────────────────┘
+```
+
+Sidebar: `200px` expanded, `68px` collapsed. Persists across pages. Collapse state in localStorage.
+
+### Page Archetypes
+
+**Grid** (Dashboards, Cluster Overview, Metrics): `react-grid-layout` panels with drag-resize. Max 12 panels per viewport. F-pattern reading order. Dashboards serialize to the Perses resource format (`kind: "Dashboard"` with `kind: "Panel"` entries). Layout adapters in `perses/layoutAdapter.ts` convert between Perses grid specs and react-grid-layout items.
+
+**Table** (Indices, Data Streams, Ingest Pipelines, Users, Roles): Full-width sortable table with filter/search toolbar above. Detail sidebar or flyout on row click.
+
+**Explorer** (Discover, Traces, Query Lab): Split-pane with query input above, results below. Resizable split. CodeMirror editor.
+
+**Detail** (Trace Detail, Fleet Agent): Header with key metadata, tabbed content below.
+
+### Cards and Panels
+
+```tsx
+sx={{
+  bgcolor: 'background.paper',
+  border: 1,
+  borderColor: 'divider',
+  borderRadius: 2,           // 8px
+  p: 2,                       // 16px
+}}
+```
+
+No drop shadows. No gradients. Active/selected card: `2px` left border in `primary.main`. Panel headers: 36px tall, title at subtitle1, kebab menu right-aligned on hover.
+
+---
+
+## Components
+
+### Empty States
+
+Every page that can show "no data" renders the `EmptyState` component. Required anatomy:
+
+- Centered icon (48px, `text.secondary`)
+- Bold title (`subtitle1`, 600 weight)
+- One-line description (`body2`)
+- Optional action button
+
+No blank rectangles anywhere. Branching on empty data without rendering `EmptyState` is a bug.
+
+### Tables (DataTable)
+
+Column headers: `body2`, 600 weight, `text.secondary`, `textTransform: 'uppercase'`, `letterSpacing: '0.04em'`. Rows: `body1`, `text.primary`. No alternating row stripes (divider lines are sufficient). Numeric columns right-align. Pagination: `[25, 50, 100]` rows-per-page.
+
+Cell truncation via `text-overflow: ellipsis`. Hover tooltip for full value. Row click opens `RowInspectorFlyout` (right-side drawer).
+
+### Stat Cards (StatPanel)
+
+Value: `h3` (32px/700), colored by threshold or series palette, centered. Label: `body2`, `text.secondary`, below value. Multiple stats flex-wrap with `gap: 32px`.
+
+### Time Range Controls
+
+`DateRangePicker`: top-right of page header or toolbar. Compact display string ("Last 15 minutes"). Quick presets: 5m, 15m, 30m, 1h, 3h, 6h, 12h, 24h, 7d, 30d (defined in `timePresets.ts`). `RefreshIntervalPicker` adjacent right.
+
+### Query Editor
+
+CodeMirror 6 with `@codemirror/lang-sql`, ES|QL highlighting from `esqlSyntaxGuide.ts`. Background: `background.sunken`. Font: JetBrains Mono 13px. Line numbers on, minimap off. Resizable height via drag handle. Ghost-diff extension renders AI completions as dimmed inline text (Tab to accept, Escape to dismiss).
+
+### Charts (Perses)
+
+Peek uses [Perses](https://perses.dev) as its charting framework. Perses is a CNCF project built on ECharts that provides a plugin-based panel system, dashboard-as-code data model, and embeddable chart components with MUI theme integration. For architecture layers, code-structure rules, and registration steps, see DEVELOPING.md § Perses Architecture. For the migration roadmap, see PERSES_MIGRATION_PLAN.md.
+
+**Design rules for charts:**
+
+- Colors come from the theme (via `useEChartTheme()` or the Perses `ChartsProvider`). No hardcoded hex values in chart options.
+- Tooltip style: `background.raised` fill, `divider` border, `text.primary` content, 12px Inter. Crosshair cursor on time-series.
+- For charts with >8 series, enable hover-to-highlight and click-to-isolate.
+- Export via `getDataURL()`. Chart data must also be accessible as a table via the Inspect panel.
+
+### Sidebar Navigation
+
+Section headers: 11px/600, `text.secondary`, uppercase, `letterSpacing: '0.02em'`. Active item: `primary.main` text+icon, 3px left accent bar, `action.selected` background. Items built from `PAGE_MANIFEST` — never hardcoded.
+
+### Connection Dialog
+
+Centered dialog. URL input, auth tabs (API Key / Username+Password), Connect button. Profiles via `connectionProfileSlice.ts`, switchable via `ConnectionProfileSwitcher`.
+
+### Command Palette
+
+`Cmd+K` / `Ctrl+K`. Centered modal, search input. Results grouped: Navigation, Actions, Recent Queries.
+
+---
+
+## Interaction Patterns
+
+### Loading
+
+Indeterminate `LinearProgress` bar below toolbar, above content. Components render structural skeleton (headers, empty card boundaries) — never a spinner, never a blank screen.
+
+### Errors
+
+Inline `Alert` with `severity="error"` at top of affected content area. Includes error message and "Retry" action. Errors never block navigation to other pages.
+
+### Transitions
+
+Route changes: instant, no animation. Panel resize / sidebar collapse: `theme.transitions.duration.shorter` (150ms). Chart rendering: no entrance animation. Respect `prefers-reduced-motion`.
+
+### Keyboard
+
+All interactive elements reachable via Tab. Escape dismisses any overlay. Focus rings use browser default — never suppress `outline`. Command palette is the keyboard shortcut hub.
+
+---
+
+## Accessibility
+
+WCAG 2.2 Level AA is the floor.
+
+- **4.5:1** contrast for body text (14px)
+- **3:1** for large text (≥18px or ≥14px bold) and non-text UI (borders, icons, chart elements)
+- Status: always color + icon + text label
+- Form inputs: visible `<label>` via `htmlFor`
+- Semantic HTML: `<button>` for actions, `<a>` for navigation, `<nav>` / `<main>` landmarks
+- Focus: moves to main content on route change, returns to trigger on dialog close
+- `aria-current="page"` on active sidebar item
+- `aria-label` on icon-only buttons
+- Chart data accessible as table via "Inspect" panel action
+
+---
+
+## Banned Patterns
+
+These are never correct in this codebase. Agents must not generate them. For engineering/code-structure bans (barrel imports, direct ECharts imports, data fetching in chart components), see DEVELOPING.md § Banned Code Patterns.
+
+```tsx
+// ❌ Inline hex colors
+<Box sx={{ color: '#69707D', bgcolor: '#25262E' }}>
+// ✅
+<Box sx={{ color: 'text.secondary', bgcolor: 'background.paper' }}>
+
+// ❌ Disallowed Typography variants
+<Typography variant="h4">Section Title</Typography>
+// ✅
+<Typography variant="subtitle1">Section Title</Typography>
+
+// ❌ Clickable divs
+<Box onClick={handleClick} sx={{ cursor: 'pointer' }}>
+// ✅
+<Button onClick={handleClick}>
+// ✅ (if unstyled)
+<ButtonBase onClick={handleClick}>
+
+// ❌ Spinner for loading
+<CircularProgress />
+// ✅
+<LinearProgress />
+
+// ❌ Drop shadows on surfaces
+<Paper elevation={3}>
+// ✅
+<Paper elevation={0} sx={{ border: 1, borderColor: 'divider' }}>
+
+// ❌ Gradients on surfaces
+<Box sx={{ background: 'linear-gradient(...)' }}>
+// ✅
+<Box sx={{ bgcolor: 'background.paper' }}>
+
+// ❌ Blank rectangle when data is empty
+{data.length === 0 && <Box />}
+// ✅
+{data.length === 0 && <EmptyState heading="No results" description="..." />}
+
+// ❌ Hardcoded colors in ECharts options
+series: [{ itemStyle: { color: '#0077CC' } }]
+// ✅ Colors come from useEChartTheme() or ChartsProvider
+const theme = useEChartTheme();
+```

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -21,9 +21,8 @@
 
 - **Node.js** `^20.19.0` or `>=22.12.0` (required by Vite 7)
 - **npm** `>=10` (bundled with Node.js 20/22)
-- **GNU Make** — pre-installed on macOS and most Linux distributions. On Windows, install via [Chocolatey](https://chocolatey.org/) (`choco install make`), [Scoop](https://scoop.sh/) (`scoop install make`), or use WSL.
-
-Use a version manager such as [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to switch Node versions quickly. A `.nvmrc` file is included in this repo — run `nvm use` or `fnm use` at the repo root to activate the correct version automatically.
+- **GNU Make** (pre-installed on macOS/Linux)
+- `.nvmrc` included — run `nvm use` or `fnm use` to activate the correct version
 
 ## Quick Start
 
@@ -46,106 +45,37 @@ make otel-down         # stop and remove local OTel stack
 make otel-cloud-up     # send OTel data to a remote cluster (set ES_URL, ES_API_KEY)
 ```
 
-> **Note:** `make serve` and `make serve-proxy` auto-install dependencies. The other targets (`lint`, `format`, `build`, `test-*`) assume dependencies are already installed — run `make setup` once first.
-
-If `make` is unavailable, run the equivalent npm commands directly from the `peek/` directory:
-
-```bash
-cd peek
-npm install        # install dependencies (replaces make setup)
-npm run dev        # start dev server (replaces make serve)
-npm run build      # production build (replaces make build)
-npm run lint       # lint (replaces make lint)
-npm run format     # format (replaces make format)
-npm run electron:dev   # start Electron dev mode (replaces make electron-dev)
-npm run electron:build # build Electron app (replaces make electron-build)
-npm run electron:dist  # package for distribution (replaces make electron-dist)
-```
-
-> **Pre-commit hook:** `make setup` (or `npm install` inside `peek/`) also installs a [husky](https://typicode.github.io/husky/) pre-commit hook that automatically runs Prettier (format) and ESLint (lint) on staged files via [lint-staged](https://github.com/lint-staged/lint-staged). This keeps committed code consistently formatted and lint-free.
+`make setup` must run first. `make serve` and `make serve-proxy` auto-install dependencies. A husky pre-commit hook runs Prettier + ESLint on staged files.
 
 ## Running with a Proxy
 
-Use `make serve-proxy` (or `ES_URL=... npm run dev` in the `peek/` directory) to start the Vite dev server with a built-in proxy. The proxy forwards requests to your Elasticsearch cluster, so no CORS configuration is needed on Elasticsearch.
+`make serve-proxy` starts Vite with a built-in proxy — no CORS configuration needed on Elasticsearch.
 
 ```bash
 ES_URL=http://localhost:9200 make serve-proxy
 ```
 
-Then enter `http://localhost:3000/_es` as the Elasticsearch URL when connecting the dashboard. The `/_es` prefix proxies all Elasticsearch API requests (connection validation, cluster health, queries, data streams, field caps, API console, etc.) to `ES_URL`.
-
-```
-┌─────────────┐    /_es/*       ┌──────────────────┐    /*             ┌────────────────────┐
-│   Browser    │ ─────────────▶  │  Vite dev server  │ ─────────────▶  │   Elasticsearch    │
-│              │ ◀─────────────  │  (localhost:3000) │ ◀─────────────  │   cluster          │
-└─────────────┘    JSON          └──────────────────┘    JSON          └────────────────────┘
-```
+Connect to `http://localhost:3000/_es` in the dashboard. The `/_es` prefix proxies all ES API requests to `ES_URL`.
 
 ## Electron Mode
 
-Electron mode packages Peek as a native desktop application. The Electron main process handles Elasticsearch requests over IPC, which means the browser-side CORS restriction no longer applies — no proxy or CORS configuration is required. Use this runtime when:
+Electron packages Peek as a native desktop app. ES requests go over IPC — no CORS or proxy needed.
 
-- You cannot or do not want to add CORS headers to Elasticsearch.
-- You want a native desktop app rather than a browser tab.
-- You are distributing Peek to users who should not need to manage a local proxy.
+```bash
+make electron-dev    # dev mode with hot-reload + DevTools
+make electron-build  # compile renderer + main process
+make electron-dist   # package distributable (dmg/exe/AppImage) to peek/dist-packages/
+```
 
-### When to choose each runtime
-
-| Runtime | Requires CORS on ES? | Requires local proxy? | Distribution |
+| Runtime | CORS on ES? | Proxy? | Distribution |
 | --- | --- | --- | --- |
 | Browser (direct) | Yes | No | Static site / GitHub Pages |
-| Browser + proxy (`make serve-proxy`) | No | Yes (Vite or nginx) | Docker image |
-| Electron (`make electron-dev`) | No | No | Native desktop app |
-
-### Running in Electron
-
-```bash
-make electron-dev   # start Electron app in dev mode (Vite hot-reload + DevTools)
-```
-
-Enter your Elasticsearch URL and credentials in the connection dialog just as you would in browser mode. The app automatically uses the IPC transport instead of `fetch` when running inside Electron.
-
-### Building and distributing
-
-```bash
-make electron-build  # compile renderer (peek/dist/) + main process (peek/dist-electron/)
-make electron-dist   # package distributable: macOS .dmg / Windows .exe / Linux .AppImage
-                     # output written to peek/dist-packages/
-```
-
-The packaged app is self-contained — users do not need Node.js, npm, or a proxy server installed.
-
-**Architecture (Electron mode):**
-```
-┌─────────────────────────────────────────────────┐
-│  Electron app                                    │
-│  ┌──────────────┐  IPC   ┌────────────────────┐ │
-│  │  Renderer    │ ─────▶  │  Main process      │ │     ┌────────────────────┐
-│  │  (React UI)  │ ◀─────  │  (Node.js / IPC    │ │────▶│   Elasticsearch    │
-│  └──────────────┘        │   handlers)         │ │◀────│   cluster          │
-│                           └────────────────────┘ │     └────────────────────┘
-└─────────────────────────────────────────────────┘
-```
+| Browser + proxy | No | Yes | Docker image |
+| Electron | No | No | Native desktop app |
 
 ## Architecture
 
-The dashboard is a static single-page application. Elasticsearch queries are made directly from the browser, or via a local proxy that avoids CORS.
-
-**Direct mode** (requires CORS on Elasticsearch):
-```
-┌─────────────┐    ES|QL     ┌────────────────────┐
-│   Browser    │ ──────────▶  │   Elasticsearch    │
-│  (static)    │ ◀──────────  │   cluster          │
-└─────────────┘    JSON       └────────────────────┘
-```
-
-**Proxy mode** (no CORS required):
-```
-┌─────────────┐    /_es/*       ┌───────────┐    /*            ┌────────────────────┐
-│   Browser    │ ─────────────▶  │   Proxy   │ ─────────────▶  │   Elasticsearch    │
-│              │ ◀─────────────  │  (local)  │ ◀─────────────  │   cluster          │
-└─────────────┘    JSON          └───────────┘    JSON          └────────────────────┘
-```
+Static SPA. Three runtimes: direct browser→ES (requires CORS), browser→proxy→ES (no CORS), or Electron IPC (no CORS). See § Electron Mode for the comparison table.
 
 ### Key Design Decisions
 
@@ -162,6 +92,23 @@ The dashboard is a static single-page application. Elasticsearch queries are mad
 4. Give the descriptor a unique `order` value so it appears in the desired picker order.
 
 `vizRegistry.tsx` discovers descriptor modules automatically with `import.meta.glob`, so no central registration file edits are required for new visualization types.
+
+## Perses Architecture
+
+Peek uses [Perses](https://perses.dev) as its charting framework (CNCF project, ECharts-based). For visual/theming rules (tooltip style, colors, series behavior), see DESIGN_LANGUAGE.md § Charts. For the full migration roadmap, see PERSES_MIGRATION_PLAN.md.
+
+**Architecture layers:**
+
+- **Data model** — dashboards serialize to the Perses resource format (`kind: "Dashboard"`, panels as `kind: "Panel"` with plugin kinds). Adapters in `services/perses/dashboardAdapters.ts` convert between internal `DashboardDefinition` and the Perses wire format.
+- **Panel plugins** — each visualization type maps to a Perses plugin kind via `VISUALIZATION_TO_PLUGIN_KIND` in the adapter layer (`TimeSeriesChart`, `StatChart`, `GaugeChart`, `BarChart`, `TablePanel`, `PieChart`, `ScatterChart`, `HeatMapChart`, `HistogramChart`, `MarkdownPanel`).
+- **Viz registry** — `vizRegistry.tsx` and `components/perses/panelRegistry.ts` use the same `VizRegistryEntry` interface. Registry entries are auto-discovered from `visualizations/registry/*.tsx`.
+- **Rendering** — charts render through `EChartWrapper`, which wraps the ECharts core that Perses itself uses internally. Do not import ECharts directly in new chart components; use `EChartWrapper` or Perses's `@perses-dev/components` `EChart` component.
+- **Theming** — `useEChartTheme()` produces ECharts-compatible options from MUI palette tokens. This hook is modeled on Perses's `generateChartsTheme` and will be replaced by Perses's `ChartsProvider` context once the migration completes. Until then, all chart theming flows through this single hook — charts never set their own colors.
+
+**Code-structure rules for chart components:**
+
+- Chart components receive data via `VizRendererProps`. They do not fetch data — the panel container handles queries.
+- New chart types must be registered as a `VizRegistryDescriptor` in `visualizations/registry/`. One file per chart type.
 
 ## Adding a New Elasticsearch Endpoint
 
@@ -188,129 +135,61 @@ This structure ensures that **adding types to an existing domain** only touches 
 
 ## Docker
 
-The `Dockerfile` produces a self-contained image that serves the built dashboard with nginx and proxies `/_es/*` to Elasticsearch. No CORS configuration on Elasticsearch is required.
+Self-contained image: nginx serves the built dashboard and proxies `/_es/*` to Elasticsearch (no CORS needed).
 
 ```bash
 make docker-build                              # build the image
-make docker-run                                # run against host Elasticsearch (port 9200)
+make docker-run                                # run against localhost:9200
 ES_URL=https://my-cluster:9200 make docker-run # run against a remote cluster
 ```
 
-Or with Docker Compose:
-
-```bash
-ES_URL=http://my-elasticsearch:9200 docker compose up
-```
-
-Open `http://localhost:8080` and enter `http://localhost:8080/_es` as the Elasticsearch URL. The nginx proxy inside the container forwards `/_es` requests (with path rewriting) to `ES_URL`. See `docker/nginx.conf.template` for the proxy configuration.
+Connect to `http://localhost:8080/_es`. See `docker/nginx.conf.template` for proxy config.
 
 ## OTel Telemetry Stack
 
 Generate real telemetry in `metrics-*`, `traces-*`, and `logs-*` indices using an EDOT collector and synthetic generators.
 
-### Local (with Elasticsearch)
+### Local
 
 ```bash
-make otel-up      # starts ES + EDOT collector + otelgen traces & logs
+make otel-up      # ES (localhost:9200) + EDOT collector + otelgen traces/logs + Fleet agent simulator
 make otel-logs    # tail collector logs
-make otel-down    # stop and remove everything
+make otel-down    # stop everything
 ```
 
-This starts:
-- Elasticsearch (`http://localhost:9200`)
-- EDOT collector (Elastic Agent in OTel mode — `hostmetrics` + OTLP receiver + ES exporter)
-- otelgen traces generator (synthetic multi-service traces via OTLP)
-- otelgen logs generator (synthetic logs via OTLP)
-- Fleet agent simulator that writes representative Fleet documents to `fleet-agents-sim` for Cluster Overview testing
-
-### Remote (Elastic Cloud or any ES endpoint)
+### Remote
 
 ```bash
 ES_URL=https://my-cluster.es.cloud:443 ES_API_KEY=... make otel-cloud-up
-make otel-cloud-logs
 make otel-cloud-down
-```
-
-This starts only the EDOT collector and generators — no local Elasticsearch.
-
-### Quick data check
-
-```bash
-curl -s -X POST 'http://localhost:9200/_query' \
-  -H 'Content-Type: application/json' \
-  -d '{"query":"FROM metrics-hostmetricsreceiver-default | STATS count = COUNT(*) BY dataset = data_stream.dataset, metric_type = type | SORT count DESC"}'
 ```
 
 ### OTLP Fixture Capture & Replay
 
-Pre-captured OTLP data in `peek/fixtures/otlp/` can be replayed into a fresh
-Elasticsearch without running the generators. This is faster and deterministic.
+Pre-captured OTLP data in `peek/fixtures/otlp/` — faster and deterministic, no generators needed.
 
 ```bash
 make otel-replay-up    # start ES + EDOT collector in replay mode
-make otel-replay       # replay OTLP fixtures + seed non-OTLP data (web_logs, orders, pipelines)
-make test-e2e-live     # run Playwright tests against real data
+make otel-replay       # replay fixtures + seed non-OTLP data (web_logs, orders, pipelines)
+make test-e2e-live     # Playwright tests against real data
 make otel-replay-down  # stop everything
 ```
 
-The replay script (`peek/scripts/otel-replay.mjs`) reads `.jsonl.gz` fixtures,
-rewrites timestamps to be relative to now, and sends via OTLP/HTTP to the
-collector. Data flows through the same elasticapm pipeline as live data.
-
-To re-capture fixtures from the live stack:
-
-```bash
-make otel-capture       # start OTel stack with file exporters
-# wait ~30 seconds
-make otel-capture-down  # stop and gzip captures
-# commit peek/fixtures/otlp/*.jsonl.gz
-```
-
-See `peek/fixtures/otlp/README.md` for details.
+Re-capture: `make otel-capture`, wait ~30s, `make otel-capture-down`. See `peek/fixtures/otlp/README.md`.
 
 ## Fleet Harness
 
-Use this harness to run a real Fleet Server stack with enrolled Elastic Agents. This produces the actual Fleet and agent telemetry data streams that the Fleet page consumes.
+Real Fleet Server stack with enrolled Elastic Agents. Allow 3-5 minutes for full initialization.
 
 ```bash
-make fleet-harness-up
+make fleet-harness-up     # ES (localhost:9220, elastic/changeme) + Kibana + Fleet Server + 2 agents
+make fleet-harness-down   # stop everything
+make fleet-harness-logs   # tail Fleet Server logs
 ```
-
-This starts (allow 3-5 minutes for full initialization):
-
-- Elasticsearch with security enabled (`http://localhost:9220`, user `elastic`, password `changeme`)
-- Kibana with Fleet auto-configuration (`http://localhost:5601`)
-- Fleet Server (`http://localhost:8220`)
-- Two enrolled Elastic Agents (`agent-host-01`, `agent-host-02`)
-
-Data streams produced:
-
-- `metrics-fleet_server.agent_status-default` — aggregate agent counts
-- `metrics-fleet_server.agent_versions-default` — agent count per version
-- `logs-fleet_server.output_health-default` — output health
-- `logs-elastic_agent-default` — agent logs
-- `metrics-elastic_agent.*-default` — agent metrics (CPU, memory)
 
 Connect Peek to `http://localhost:9220` with credentials `elastic` / `changeme`.
 
-Stop with:
-
-```bash
-make fleet-harness-down
-```
-
-Tail Fleet Server logs:
-
-```bash
-make fleet-harness-logs
-```
-
-Quick data check:
-
-```bash
-curl -sf -u elastic:changeme \
-  'http://localhost:9220/_cat/indices/metrics-fleet_server*,logs-fleet_server*,logs-elastic_agent*,metrics-elastic_agent*?v&h=index,docs.count,store.size'
-```
+Data streams: `metrics-fleet_server.agent_status-default`, `metrics-fleet_server.agent_versions-default`, `logs-fleet_server.output_health-default`, `logs-elastic_agent-default`, `metrics-elastic_agent.*-default`.
 
 ## Testing
 
@@ -321,16 +200,12 @@ make test-e2e         # Playwright browser tests (starts dev server automaticall
 make test             # run all (unit, integration, e2e)
 ```
 
-Unit tests (`peek/tests/unit/`) run in jsdom via Vitest. Integration tests (`peek/tests/integration/`) use [Testcontainers](https://testcontainers.com/) to start a real Elasticsearch instance, seed test data, and run ES|QL queries through the app's `executeEsql` service. **Docker must be running** for integration tests.
+Unit tests run in jsdom via Vitest. Integration tests use Testcontainers (**Docker must be running**). E2E tests use Playwright — run `npx playwright install chromium` if the browser binary is missing.
 
-E2E tests (`peek/tests/e2e/`) use [Playwright](https://playwright.dev/) to launch a real browser against the Vite dev server. Playwright and the Chromium browser are installed as devDependencies — run `npx playwright install chromium` if the browser binary is missing.
-
-To run E2E tests against live Elasticsearch data, start the OTel harness first:
+E2E with live data:
 
 ```bash
-make otel-up                                 # start ES + EDOT collector
-ES_URL=http://localhost:9200 make test-e2e   # run e2e tests with proxy
-make otel-down                               # stop when done
+make otel-up && ES_URL=http://localhost:9200 make test-e2e && make otel-down
 ```
 
 ### Exploratory Testing Agents
@@ -350,39 +225,22 @@ They do NOT run pre-written test suites — deterministic E2E tests run in CI.
 | Customer: Feature Gap Review | Missing features, feature requests, comparison to Kibana/Grafana/Elasticvue | `explore-customer-feedback.yml` |
 | Design: Modern UI Review | Design modernization, spacing, typography, cards, tables, empty states, loading patterns | `ui-designer-review.yml` |
 
-Each agent writes and runs its own Playwright scripts to navigate, click, type,
-and inspect. They report only genuine bugs found through hands-on exploration.
+Agents use **Playwright MCP tools** (`browser_navigate`, `browser_click`,
+`browser_type`, `browser_snapshot`, `browser_take_screenshot`) for interactive
+browser exploration. They do NOT write Node.js scripts — the MCP tools allow
+step-by-step interaction where the agent sees the page state after each action
+and adapts. They report only genuine bugs.
 
 #### Handling failures during exploration
 
-When a Playwright interaction fails (timeout, element not found, unexpected state):
-
-1. **Do not retry the same action more than twice.** If it fails twice, the page
-   state is different from what you expected — retrying won't help.
-2. **Diagnose before moving on.** Take a screenshot at the point of failure.
-   Inspect the DOM to see what's actually on the page. Check if the element
-   exists with a different selector, or if the UI is in an unexpected state.
-3. **Adapt or report.** Either work around the failure (try a different selector,
-   a different interaction path, or skip to the next scenario) or report the
-   failure as a finding — a persistent timeout on an expected UI element is
-   itself a potential bug worth filing.
-4. **Never claim you verified something you didn't.** If a scenario failed and
-   you skipped it, say so in your output. Do not list it as "verified" or
-   "no issues found."
-
-### Testing Philosophy
-
-- **Test behavior, not implementation** — assert on what the user sees and what the system does, not internal wiring.
-- **Fast by default** — all unit and component tests run in jsdom via Vitest with no browser, Docker, or network.
-- **Component tests over E2E** — render real React components with `@testing-library/react` + `userEvent` to catch rendering bugs and interaction flows.
-- **No trivial tests** — every test should describe a behavior someone cares about; skip "renders without crashing" tests with zero assertions.
-- **Mock at boundaries** — mock `fetch`, `localStorage`, `echarts/core`; everything else uses real code paths.
+- Do not retry the same action more than twice — the page state is different from expected.
+- Diagnose before moving on: use `browser_take_screenshot` and `browser_snapshot` to see what's on the page.
+- Adapt (different selector/path) or report the failure as a finding.
+- Never claim you verified something you didn't — if it failed and you skipped it, say so.
 
 ### CI
 
-`make ci` runs lint + unit tests + build on every push to `main` and on every PR that touches `peek/**`. Integration tests are not part of the default CI pipeline — run them locally with `make test-integration`.
-
-Production builds (`make build`) output to `peek/dist/` and are deployed to GitHub Pages by the `deploy-pages.yml` workflow on every push to `main`.
+`make ci` runs lint + unit tests + build on every push to `main` and on PRs touching `peek/**`. Integration tests run locally only (`make test-integration`). Production builds deploy to GitHub Pages via `deploy-pages.yml`.
 
 ## Engineering Standards
 
@@ -403,20 +261,45 @@ Many rules (no `any`, `import type`, import ordering, no duplicate imports) are 
 
 Use the simplest solution that works, in this order: `useState` → derived state (compute during render) → `useReducer` → React Context → URL state → Zustand.
 
+### UI Components
+
+Shared layout and feedback components (`EmptyState`, `ContentSkeleton`, `PageHeader`) are specified in DESIGN_LANGUAGE.md § Components. Use them instead of one-off implementations.
+
 ### Testing Standards
 
-- Include at least one `vitest-axe` accessibility check per component test suite (`expect(await axe(container)).toHaveNoViolations()`).
 - Test behavior (what the user sees), not implementation details (internal state, hook call counts).
 - Test error states, loading states, and empty states — not just the happy path.
+- Include at least one `vitest-axe` accessibility check per component test suite.
+- Prefer component tests (`@testing-library/react` + `userEvent`) over E2E for rendering and interaction.
+- Mock at boundaries (`fetch`, `localStorage`, `echarts/core`); everything else uses real code paths.
+- No trivial tests — skip "renders without crashing" with zero assertions.
+
+### Banned Code Patterns
+
+See DESIGN_LANGUAGE.md § Banned Patterns for visual/design bans (inline hex, drop shadows, disallowed variants, etc.).
+
+```tsx
+// ❌ Barrel MUI imports (breaks tree-shaking)
+import { Box, Typography } from '@mui/material';
+// ✅
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+
+// ❌ Direct ECharts import in chart components
+import * as echarts from 'echarts/core';
+// ✅ Use the wrapper or Perses component
+import EChartWrapper from './EChartWrapper';
+
+// ❌ Fetching data inside a chart component
+useEffect(() => { fetchData(query) }, [query]);
+// ✅ Chart components receive data via VizRendererProps — the panel container fetches
+```
 
 ## Accessibility Standards
 
-This project targets **WCAG 2.2 Level AA** conformance. Many structural issues (missing alt text, invalid ARIA, click without keyboard, missing labels) are caught by `eslint-plugin-jsx-a11y` and `vitest-axe`. This section covers what automation cannot catch.
+This project targets **WCAG 2.2 Level AA** conformance. For contrast ratios, color usage rules, and visual accessibility requirements, see DESIGN_LANGUAGE.md § Accessibility.
 
-### Color & Contrast
-
-- 4.5:1 contrast ratio for normal text, 3:1 for large text (>= 18pt or >= 14pt bold), 3:1 for UI components and graphical objects.
-- Never use color as the sole means of conveying information — add an icon, text, or pattern.
+Many structural issues (missing alt text, invalid ARIA, click without keyboard, missing labels) are caught by `eslint-plugin-jsx-a11y` and `vitest-axe`. This section covers the implementation guidance that automation cannot catch.
 
 ### Keyboard & Focus
 
@@ -443,7 +326,7 @@ This project targets **WCAG 2.2 Level AA** conformance. Many structural issues (
 For any PR that modifies UI, verify the items that CI cannot check automatically:
 
 - [ ] Interactive elements are keyboard accessible (tab, activate, dismiss)
-- [ ] Color contrast meets the ratios above
+- [ ] Color contrast meets DESIGN_LANGUAGE.md § Accessibility ratios
 - [ ] Color is not the sole indicator of meaning
 - [ ] Focus is managed correctly on route changes and dialog open/close
 - [ ] Loading, empty, and error states are handled and designed

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Elastic Peek is a browser-based dashboard builder that connects directly to your
 
 Use a version manager such as [nvm](https://github.com/nvm-sh/nvm) or [fnm](https://github.com/Schniz/fnm) to switch Node versions quickly. A `.nvmrc` file is included in this repo — run `nvm use` or `fnm use` at the repo root to activate the correct version automatically.
 
+See [DEVELOPING.md](DEVELOPING.md) for the full development guide.
+
 ### Quick Start
 
 ```bash
@@ -86,20 +88,11 @@ npm install   # install dependencies
 npm run dev   # start dev server at http://localhost:3000
 ```
 
-Or use the built-in proxy to avoid CORS (see [DEVELOPING.md](DEVELOPING.md#running-with-a-proxy)):
+To avoid CORS, use the built-in proxy or Electron mode — see [DEVELOPING.md](DEVELOPING.md#running-with-a-proxy) for details.
 
 ```bash
-ES_URL=http://localhost:9200 make serve-proxy
-# or without make:
-cd peek && ES_URL=http://localhost:9200 npm run dev
-```
-
-Or run as a native desktop app via Electron — no CORS configuration or proxy required (see [DEVELOPING.md](DEVELOPING.md#electron-mode)):
-
-```bash
-make electron-dev    # start Electron app in dev mode (hot-reloads)
-make electron-build  # compile renderer + main process
-make electron-dist   # package as a distributable app (dmg / exe / AppImage)
+ES_URL=http://localhost:9200 make serve-proxy  # proxy mode
+make electron-dev                               # native desktop app (no CORS needed)
 ```
 
 ### In-Product Docs


### PR DESCRIPTION
## Summary

- Deduplicate repeated content across 5 docs files by replacing copy-paste sections with cross-references
- Each document now has a clearer role with cross-references replacing restated guidance
- Compressed DEVELOPING.md for agent consumption (removed npm equivalents, duplicate diagrams, verbose prose)
- Added Perses architecture and engineering standards to DEVELOPING.md, while introducing DESIGN_LANGUAGE.md as the design-only authority
- Replaced restated rules in AGENTS.md with cross-references to source documents
- Fixed false "lint error" claims and an incorrect file path

## Test plan

- [ ] Verify all cross-reference links point to correct section headings
- [ ] Confirm no orphaned references (e.g., "ratios above" pointing to removed sections)
- [ ] Check that no make commands or file paths were lost in the trimming

> Generated by [Update PR Body](https://github.com/elastic/ai-github-actions-playground/actions/runs/22550113191) for issue #1047

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22550113191, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions-playground/actions/runs/22550113191 -->