### PR TITLE
ci: add dependency review workflow for dependabot/renovate PRs

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,19 @@
+name: Dependency Review
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+jobs:
+  run:
+    if: >-
+      github.event.pull_request.user.login == 'dependabot[bot]' ||
+      github.event.pull_request.user.login == 'renovate[bot]'
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-dependency-review.lock.yml@main
+    secrets:
+      COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `dependency-review.yml` — the `gh-aw` dependency review workflow from [elastic/ai-github-actions](https://github.com/elastic/ai-github-actions/blob/main/.github/workflows/trigger-dependency-review.yml).

This workflow triggers on all dependabot and renovate PRs and posts an AI-generated analysis comment reviewing the dependency changes.

There are currently **5 open dependabot PRs** that will benefit from this:
- #1057 vitest bump
- #1058 react / @types/react bump  
- #1059 @uiw/react-codemirror bump
- #1060 @opentelemetry bump
- #1061 echarts 5→6 major bump

## Why
The playground uses renovate (`renovate.json` exists) and dependabot PRs appear regularly. The ai-github-actions repo already uses this workflow. It's a straightforward port.