### PR TITLE
fix: use localhost for Vite dev server health checks in CI

### DIFF
--- a/.github/agents/copilot-coding-agent.md
+++ b/.github/agents/copilot-coding-agent.md
@@ -61,7 +61,7 @@ When a change affects the visual appearance of the dashboard, you **must** captu
 ```bash
 cd peek && npm run dev &
 DEV_PID=$!
-for i in $(seq 1 30); do curl -sf http://127.0.0.1:3000/ai-github-actions-playground/ >/dev/null && break; sleep 1; done
+for i in $(seq 1 30); do curl -sf http://localhost:3000/ai-github-actions-playground/ >/dev/null && break; sleep 1; done
 ```
 
 2. Run the screenshot preflight, passing `--url` with the route that shows your feature (not the default connections page):

--- a/.github/workflows/ui-smoke-test-pr-review.yml
+++ b/.github/workflows/ui-smoke-test-pr-review.yml
@@ -54,7 +54,7 @@ jobs:
           DEV_PID=$!
           SERVER_READY=false
           for i in $(seq 1 30); do
-            if curl -sf http://127.0.0.1:3000/ai-github-actions-playground/ >/dev/null 2>&1; then SERVER_READY=true; break; fi
+            if curl -sf http://localhost:3000/ai-github-actions-playground/ >/dev/null 2>&1; then SERVER_READY=true; break; fi
             sleep 1
           done
           if [ "$SERVER_READY" = false ]; then
@@ -63,7 +63,7 @@ jobs:
             exit 1
           fi
           node scripts/screenshot-preflight.mjs \
-            --url http://127.0.0.1:3000/ai-github-actions-playground/ \
+            --url http://localhost:3000/ai-github-actions-playground/ \
             --output screenshot-preflight.json \
             --screenshot screenshot.png
           PREFLIGHT_EXIT=$?

--- a/peek/playwright.config.ts
+++ b/peek/playwright.config.ts
@@ -11,7 +11,7 @@ export default defineConfig({
   projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
   webServer: {
     command: "npm run dev -- --port 3000",
-    url: "http://127.0.0.1:3000/ai-github-actions-playground/",
+    url: "http://localhost:3000/ai-github-actions-playground/",
     reuseExistingServer: !process.env.CI,
     timeout: process.env.CI ? 120_000 : undefined,
   },


### PR DESCRIPTION
## Summary

Fixes the Playwright smoke test and screenshot preflight failures in CI where the Vite dev server is unreachable. Vite binds to `localhost` which resolves to `::1` (IPv6) on Ubuntu CI runners, but health checks were using `127.0.0.1` (IPv4-only), causing connection failures.

## Changes

- `peek/playwright.config.ts`: Changed `webServer.url` from `http://127.0.0.1:3000/...` to `http://localhost:3000/...`
- `.github/workflows/ui-smoke-test-pr-review.yml`: Changed curl and preflight `--url` from `127.0.0.1` to `localhost`
- `.github/agents/copilot-coding-agent.md`: Updated curl example to use `localhost`

## Checklist

- [x] Ran `make check` successfully (lint + unit tests + build)
- [ ] Included a screenshot if I made a UX change — N/A (infra-only change)
- [ ] Updated documentation if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)