### PR TITLE
fix: resolve no-circular-progress lint errors breaking CI

### DIFF
--- a/peek/src/components/ChatPage.tsx
+++ b/peek/src/components/ChatPage.tsx
@@ -265,7 +265,7 @@ export default function ChatPage({ hideHeader = false }: { hideHeader?: boolean 
           disabled={!input.trim() || loading}
           aria-label="Send message"
         >
-          {loading ? <CircularProgress size={24} /> : <SendIcon />}
+          {loading ? <CircularProgress size={16} /> : <SendIcon />}
         </IconButton>
       </Box>
     </Box>

--- a/peek/src/components/DimensionOverviewGrid.tsx
+++ b/peek/src/components/DimensionOverviewGrid.tsx
@@ -4,6 +4,7 @@ import ButtonBase from "@mui/material/ButtonBase";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 import CircularProgress from "@mui/material/CircularProgress";
+import Skeleton from "@mui/material/Skeleton";
 import Chip from "@mui/material/Chip";
 import Button from "@mui/material/Button";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
@@ -341,18 +342,8 @@ export default function DimensionOverviewGrid({
         {isLoading &&
           dimsWithData.length === 0 &&
           dimensionFields.slice(0, 6).map((field) => (
-            <Paper
-              key={`loading-${field.name}`}
-              variant="outlined"
-              sx={{
-                display: "flex",
-                justifyContent: "center",
-                alignItems: "center",
-                minHeight: 180,
-                p: 1,
-              }}
-            >
-              <CircularProgress size={24} />
+            <Paper key={`loading-${field.name}`} variant="outlined" sx={{ minHeight: 180, p: 1 }}>
+              <Skeleton variant="rounded" height="100%" />
             </Paper>
           ))}
       </Box>

--- a/peek/src/components/ExplorePage.tsx
+++ b/peek/src/components/ExplorePage.tsx
@@ -6,7 +6,7 @@ import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
 import Alert from "@mui/material/Alert";
 import Chip from "@mui/material/Chip";
-import CircularProgress from "@mui/material/CircularProgress";
+import LinearProgress from "@mui/material/LinearProgress";
 import FormControl from "@mui/material/FormControl";
 import InputLabel from "@mui/material/InputLabel";
 import Select from "@mui/material/Select";
@@ -630,18 +630,7 @@ export default function ExplorePage() {
               />
             )}
 
-            {queryResult.status === "loading" && (
-              <Box
-                sx={{
-                  display: "flex",
-                  justifyContent: "center",
-                  alignItems: "center",
-                  height: "100%",
-                }}
-              >
-                <CircularProgress size={32} />
-              </Box>
-            )}
+            {queryResult.status === "loading" && <LinearProgress />}
 
             {chartData && (
               <Box sx={{ flex: 1, minHeight: 300 }}>

--- a/peek/src/components/FieldStatsPanel.tsx
+++ b/peek/src/components/FieldStatsPanel.tsx
@@ -3,7 +3,7 @@ import Alert from "@mui/material/Alert";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
-import CircularProgress from "@mui/material/CircularProgress";
+import LinearProgress from "@mui/material/LinearProgress";
 import Divider from "@mui/material/Divider";
 import IconButton from "@mui/material/IconButton";
 import Paper from "@mui/material/Paper";
@@ -148,11 +148,7 @@ export default function FieldStatsPanel({
       <Box
         sx={{ display: "flex", flex: 1, flexDirection: "column", gap: 1, overflow: "auto", p: 1.5 }}
       >
-        {loading && (
-          <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
-            <CircularProgress size={24} />
-          </Box>
-        )}
+        {loading && <LinearProgress sx={{ my: 2 }} />}
 
         {!loading && error && <Alert severity="error">{error}</Alert>}
 

--- a/peek/src/components/FleetAgentPage.tsx
+++ b/peek/src/components/FleetAgentPage.tsx
@@ -20,6 +20,7 @@ import {
 import { formatBytes } from "../utils/formatBytes";
 import { useFleetAgentDetail } from "../hooks/useFleetAgentDetail";
 
+import ContentSkeleton from "./ContentSkeleton";
 import PageHeader from "./PageHeader";
 import EmptyState from "./EmptyState";
 import { stalenessSeverityToColor, formatFleetTime } from "./fleet/fleetPresentation";
@@ -85,9 +86,7 @@ export default function FleetAgentPage() {
       {error && <Alert severity="error">{error}</Alert>}
 
       {loading && !agentInfo ? (
-        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
-          <CircularProgress />
-        </Box>
+        <ContentSkeleton variant="cards" />
       ) : !agentInfo && !loading ? (
         <Alert severity="warning">
           Agent {decodedAgentId} not found in recent Elastic Agent logs.

--- a/peek/src/components/IndicesPage.tsx
+++ b/peek/src/components/IndicesPage.tsx
@@ -6,6 +6,7 @@ import Button from "@mui/material/Button";
 import Chip from "@mui/material/Chip";
 import CircularProgress from "@mui/material/CircularProgress";
 import Divider from "@mui/material/Divider";
+import LinearProgress from "@mui/material/LinearProgress";
 import FormControlLabel from "@mui/material/FormControlLabel";
 import List from "@mui/material/List";
 import ListItem from "@mui/material/ListItem";
@@ -478,11 +479,7 @@ export default function IndicesPage() {
           </Button>
         </Stack>
       )}
-      {diskUsageLoading && (
-        <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
-          <CircularProgress size={24} />
-        </Box>
-      )}
+      {diskUsageLoading && <LinearProgress sx={{ my: 2 }} />}
       {diskUsageError && <Alert severity="error">{diskUsageError}</Alert>}
       {diskUsage && (
         <Stack spacing={1.5}>

--- a/peek/src/components/MetricOverviewGrid.tsx
+++ b/peek/src/components/MetricOverviewGrid.tsx
@@ -7,6 +7,7 @@ import Collapse from "@mui/material/Collapse";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 import CircularProgress from "@mui/material/CircularProgress";
+import Skeleton from "@mui/material/Skeleton";
 import Chip from "@mui/material/Chip";
 import IconButton from "@mui/material/IconButton";
 import Tooltip from "@mui/material/Tooltip";
@@ -305,18 +306,8 @@ export default function MetricOverviewGrid({
         {isLoading &&
           metricsWithData.length === 0 &&
           namespaceMetrics.slice(0, 6).map((field) => (
-            <Paper
-              key={`loading-${field.name}`}
-              variant="outlined"
-              sx={{
-                display: "flex",
-                justifyContent: "center",
-                alignItems: "center",
-                minHeight: 140,
-                p: 1,
-              }}
-            >
-              <CircularProgress size={24} />
+            <Paper key={`loading-${field.name}`} variant="outlined" sx={{ minHeight: 140, p: 1 }}>
+              <Skeleton variant="rounded" height="100%" />
             </Paper>
           ))}
       </Box>

--- a/peek/src/components/MetricSearch.tsx
+++ b/peek/src/components/MetricSearch.tsx
@@ -111,7 +111,7 @@ export default function MetricSearch({
                 ...params.InputProps,
                 endAdornment: (
                   <>
-                    {loading ? <CircularProgress color="inherit" size={20} /> : null}
+                    {loading ? <CircularProgress color="inherit" size={16} /> : null}
                     {params.InputProps.endAdornment}
                   </>
                 ),

--- a/peek/src/components/PanelContainer.tsx
+++ b/peek/src/components/PanelContainer.tsx
@@ -24,6 +24,7 @@ import {
 import type { PanelDefinition, EsqlResponse } from "../types";
 
 import { toCsv } from "./discoverUtils";
+import ContentSkeleton from "./ContentSkeleton";
 import PersesPanelRenderer from "./perses/PersesPanelRenderer";
 import { getPersesPanelEntry } from "./perses/panelRegistry";
 import { formatMs, formatRowCount, formatTimeAgo } from "./panelBadgeUtils";
@@ -308,16 +309,7 @@ export default function PanelContainer({ panel }: Props) {
             </Typography>
           </Box>
         ) : loading && !data ? (
-          <Box
-            sx={{
-              display: "flex",
-              justifyContent: "center",
-              alignItems: "center",
-              height: "100%",
-            }}
-          >
-            <CircularProgress size={32} />
-          </Box>
+          <ContentSkeleton variant="chart" />
         ) : data ? (
           <PersesPanelRenderer
             type={panel.visualization}


### PR DESCRIPTION
## Summary

Fixes 9 `peek/no-circular-progress` ESLint errors that are failing `make lint-full` on main, blocking CI for all PRs.

## Changes

The ESLint rule disallows `CircularProgress` unless `size <= 16` or inside a `Button`. Each violation was replaced with the appropriate alternative:

| File | Before | After |
|------|--------|-------|
| ChatPage | `CircularProgress size={24}` in IconButton | Reduced to `size={16}` |
| MetricSearch | `CircularProgress size={20}` in Autocomplete | Reduced to `size={16}` |
| ExplorePage | `CircularProgress size={32}` section loader | `LinearProgress` |
| FieldStatsPanel | `CircularProgress size={24}` section loader | `LinearProgress` |
| IndicesPage | `CircularProgress size={24}` section loader | `LinearProgress` |
| FleetAgentPage | `CircularProgress` (no size) page loader | `ContentSkeleton variant="cards"` |
| PanelContainer | `CircularProgress size={32}` panel loader | `ContentSkeleton variant="chart"` |
| DimensionOverviewGrid | `CircularProgress size={24}` card placeholder | `Skeleton variant="rounded"` |
| MetricOverviewGrid | `CircularProgress size={24}` card placeholder | `Skeleton variant="rounded"` |

Closes #1087

## Checklist

- [x] Ran `make check` successfully (lint + unit tests + build)
- [ ] Included a screenshot if I made a UX change — loading states only, no functional change
- [ ] Updated documentation if applicable

🤖 Generated with [Claude Code]((claude.com/redacted)

> Generated by [Update PR Body](https://github.com/elastic/ai-github-actions-playground/actions/runs/22555837835) for issue #1089

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22555837835, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions-playground/actions/runs/22555837835 -->