### PR TITLE
ci: add title-prefix to scheduled workflows to prevent issue collisions

### DIFF
--- a/.github/workflows/agent-suggestions.yml
+++ b/.github/workflows/agent-suggestions.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-agent-suggestions.lock.yml@main
+    with:
+      title-prefix: "[agent-suggestions]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/autonomy-atomicity-analyzer.yml
+++ b/.github/workflows/autonomy-atomicity-analyzer.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-autonomy-atomicity-analyzer.lock.yml@main
+    with:
+      title-prefix: "[autonomy-atomicity]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/breaking-change-detector.yml
+++ b/.github/workflows/breaking-change-detector.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-breaking-change-detector.lock.yml@main
+    with:
+      title-prefix: "[breaking-change]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/bug-hunter.yml
+++ b/.github/workflows/bug-hunter.yml
@@ -13,5 +13,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-bug-hunter.lock.yml@main
+    with:
+      title-prefix: "[bug-hunter]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/code-duplication-detector.yml
+++ b/.github/workflows/code-duplication-detector.yml
@@ -13,6 +13,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-code-duplication-detector.lock.yml@main
     with:
+      title-prefix: "[code-duplication]"
       languages: "typescript"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/docs-patrol.yml
+++ b/.github/workflows/docs-patrol.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-docs-patrol.lock.yml@main
+    with:
+      title-prefix: "[docs-patrol]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/flaky-test-investigator.yml
+++ b/.github/workflows/flaky-test-investigator.yml
@@ -13,5 +13,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-flaky-test-investigator.lock.yml@main
+    with:
+      title-prefix: "[flaky-test-investigator]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/framework-best-practices.yml
+++ b/.github/workflows/framework-best-practices.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-framework-best-practices.lock.yml@main
+    with:
+      title-prefix: "[framework-best-practices]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/information-architecture.yml
+++ b/.github/workflows/information-architecture.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-information-architecture.lock.yml@main
+    with:
+      title-prefix: "[information-architecture]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/newbie-contributor-patrol.yml
+++ b/.github/workflows/newbie-contributor-patrol.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-newbie-contributor-patrol.lock.yml@main
+    with:
+      title-prefix: "[newbie-contributor]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/performance-profiler.yml
+++ b/.github/workflows/performance-profiler.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-performance-profiler.lock.yml@main
+    with:
+      title-prefix: "[performance-profiler]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/product-manager-impersonator.yml
+++ b/.github/workflows/product-manager-impersonator.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-product-manager-impersonator.lock.yml@main
+    with:
+      title-prefix: "[product-manager]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/project-summary.yml
+++ b/.github/workflows/project-summary.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-project-summary.lock.yml@main
+    with:
+      title-prefix: "[project-summary]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/react-state-bug-hunter.yml
+++ b/.github/workflows/react-state-bug-hunter.yml
@@ -14,6 +14,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-bug-hunter.lock.yml@main
     with:
+      title-prefix: "[react-state-bug-hunter]"
       additional-instructions: |
         Focus your investigation on React/Zustand state management bugs in this repository.
 

--- a/.github/workflows/refactor-opportunist.yml
+++ b/.github/workflows/refactor-opportunist.yml
@@ -13,5 +13,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-refactor-opportunist.lock.yml@main
+    with:
+      title-prefix: "[refactor-opportunist]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/stale-issues.yml
+++ b/.github/workflows/stale-issues.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-stale-issues.lock.yml@main
+    with:
+      title-prefix: "[stale-issues]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/text-auditor.yml
+++ b/.github/workflows/text-auditor.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-text-auditor.lock.yml@main
+    with:
+      title-prefix: "[text-auditor]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/ux-design-patrol.yml
+++ b/.github/workflows/ux-design-patrol.yml
@@ -12,5 +12,7 @@ permissions:
 jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-ux-design-patrol.lock.yml@main
+    with:
+      title-prefix: "[ux-design-patrol]"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Scheduled workflows that create issues via `ai-github-actions` reusable workflows were closing each other's issues because they shared default or empty `title-prefix` values. The `title-prefix` is used to namespace issues per workflow — without it, `close_older_issues: true` in the reusable workflow closes issues from *any* workflow with the same prefix.

## Changes

Added explicit `title-prefix` to **18 Copilot-powered scheduled workflows**:

| Workflow | Prefix |
|----------|--------|
| agent-suggestions | `[agent-suggestions]` |
| autonomy-atomicity-analyzer | `[autonomy-atomicity]` |
| breaking-change-detector | `[breaking-change]` |
| bug-hunter | `[bug-hunter]` |
| code-duplication-detector | `[code-duplication]` |
| docs-patrol | `[docs-patrol]` |
| flaky-test-investigator | `[flaky-test-investigator]` |
| framework-best-practices | `[framework-best-practices]` |
| information-architecture | `[information-architecture]` |
| newbie-contributor-patrol | `[newbie-contributor]` |
| performance-profiler | `[performance-profiler]` |
| product-manager-impersonator | `[product-manager]` |
| project-summary | `[project-summary]` |
| react-state-bug-hunter | `[react-state-bug-hunter]` |
| refactor-opportunist | `[refactor-opportunist]` |
| stale-issues | `[stale-issues]` |
| text-auditor | `[text-auditor]` |
| ux-design-patrol | `[ux-design-patrol]` |

**Already had `title-prefix` (no change needed):** give-it-some-love (`[love]`), give-it-some-love-demo (`[love-demo]`), ui-designer-review (`[design-review]`)

**Not fixable from this repo:** The 13 Gemini CLI workflows (`explore-*`, `*-ideas-man`) use `gh-aw-internal-gemini-cli.lock.yml` / `gh-aw-internal-gemini-cli-web-search.lock.yml` which have `title_prefix` hardcoded (`[gemini-cli]` / `[research]`) and don't expose it as an input. `release-update` also doesn't accept this input. These need to be fixed upstream in `elastic/ai-github-actions`.

## Checklist

- [x] Ran `make check` successfully (lint + unit tests + build)
- [ ] Included a screenshot if I made a UX change — N/A
- [ ] Updated documentation if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)