### PR TITLE
ci: add title-prefix to Gemini-powered scheduled workflows

### DIFF
--- a/.github/workflows/explore-connection.yml
+++ b/.github/workflows/explore-connection.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      title-prefix: "[explore-connection]"
       setup-commands: |
         make serve-explore
       additional-instructions: |

--- a/.github/workflows/explore-customer-feedback.yml
+++ b/.github/workflows/explore-customer-feedback.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      title-prefix: "[explore-customer-feedback]"
       setup-commands: |
         make serve-explore
       additional-instructions: |

--- a/.github/workflows/explore-data-management.yml
+++ b/.github/workflows/explore-data-management.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      title-prefix: "[explore-data-management]"
       setup-commands: |
         make serve-explore
       additional-instructions: |

--- a/.github/workflows/explore-live-es.yml
+++ b/.github/workflows/explore-live-es.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      title-prefix: "[explore-live-es]"
       setup-commands: |
         make serve-explore
       additional-instructions: |

--- a/.github/workflows/explore-metrics.yml
+++ b/.github/workflows/explore-metrics.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      title-prefix: "[explore-metrics]"
       setup-commands: |
         make serve-explore
       additional-instructions: |

--- a/.github/workflows/explore-mobile.yml
+++ b/.github/workflows/explore-mobile.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      title-prefix: "[explore-mobile]"
       setup-commands: |
         make serve-explore
       additional-instructions: |

--- a/.github/workflows/explore-query-lab.yml
+++ b/.github/workflows/explore-query-lab.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      title-prefix: "[explore-query-lab]"
       setup-commands: |
         make serve-explore
       additional-instructions: |

--- a/.github/workflows/explore-traces.yml
+++ b/.github/workflows/explore-traces.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
     with:
+      title-prefix: "[explore-traces]"
       setup-commands: |
         make serve-explore
       additional-instructions: |

--- a/.github/workflows/iterative-ideas-man.yml
+++ b/.github/workflows/iterative-ideas-man.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli-web-search.lock.yml@main
     with:
+      title-prefix: "[iterative-ideas-man]"
       additional-instructions: |
         You are a product-minded engineer who genuinely believes each idea
         "won't be that hard" to implement. You look at a project, understand

--- a/.github/workflows/medium-ideas-man.yml
+++ b/.github/workflows/medium-ideas-man.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli-web-search.lock.yml@main
     with:
+      title-prefix: "[medium-ideas-man]"
       additional-instructions: |
         You are a product-minded engineer who thinks in terms of meaningful
         product increments — features that move the needle for users and

--- a/.github/workflows/observability-ideas-man.yml
+++ b/.github/workflows/observability-ideas-man.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli-web-search.lock.yml@main
     with:
+      title-prefix: "[observability-ideas-man]"
       additional-instructions: |
         You are a **seasoned SRE and platform engineer** who lives in logs,
         metrics, and distributed traces. You manage 50+ services and rely

--- a/.github/workflows/security-ideas-man.yml
+++ b/.github/workflows/security-ideas-man.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli-web-search.lock.yml@main
     with:
+      title-prefix: "[security-ideas-man]"
       additional-instructions: |
         You are a **seasoned threat-hunter and SOC engineer** who lives in
         dashboards, detection rules, and XDR alert queues. You manage

--- a/.github/workflows/vector-search-ideas-man.yml
+++ b/.github/workflows/vector-search-ideas-man.yml
@@ -15,6 +15,7 @@ jobs:
   run:
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli-web-search.lock.yml@main
     with:
+      title-prefix: "[vector-search-ideas-man]"
       additional-instructions: |
         You are a **search engineer and AI product builder** who tunes
         relevance, embedding pipelines, and hybrid retrieval strategies.


### PR DESCRIPTION
## Summary
- Adds `title-prefix` to all 13 Gemini-powered scheduled workflows (8 `explore-*` and 5 `*-ideas-man`)
- Now that upstream PR elastic/ai-github-actions#519 exposed `title-prefix` as a configurable input on `gh-aw-internal-gemini-cli` and `gh-aw-internal-gemini-cli-web-search`, these workflows can set unique prefixes
- Prevents scheduled workflows from closing each other's issues via `close-older-issues`

## Workflows updated
| Workflow | Prefix |
|---|---|
| explore-traces | `[explore-traces]` |
| explore-connection | `[explore-connection]` |
| explore-live-es | `[explore-live-es]` |
| explore-metrics | `[explore-metrics]` |
| explore-query-lab | `[explore-query-lab]` |
| explore-data-management | `[explore-data-management]` |
| explore-customer-feedback | `[explore-customer-feedback]` |
| explore-mobile | `[explore-mobile]` |
| medium-ideas-man | `[medium-ideas-man]` |
| vector-search-ideas-man | `[vector-search-ideas-man]` |
| security-ideas-man | `[security-ideas-man]` |
| observability-ideas-man | `[observability-ideas-man]` |
| iterative-ideas-man | `[iterative-ideas-man]` |

## Test plan
- [ ] Verify workflow YAML is valid (no syntax errors on push)
- [ ] Trigger one workflow manually and confirm the issue title includes the expected prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)