### PR TITLE
fix: install system dependencies for playwright browsers

### DIFF
--- a/.github/workflows/ui-smoke-test-pr-review.yml
+++ b/.github/workflows/ui-smoke-test-pr-review.yml
@@ -35,10 +35,8 @@ jobs:
           ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 
       - name: Install Playwright Browsers & Deps
-        run: |
-          cd peek
-          npx playwright install chromium webkit
-          npx playwright install-deps chromium webkit
+        run: npx playwright install --with-deps chromium webkit
+        working-directory: peek
 
       - name: Run E2E smoke tests
         id: smoke


### PR DESCRIPTION
### Problem
Recent PR #1095 added WebKit to the smoke tests to support mobile testing. However, WebKit requires several system libraries (libgtk-4, libgstreamer, etc.) that are not present by default on `ubuntu-latest`, causing 'missing dependencies' errors.

### Solution
Added `npx playwright install --with-deps chromium webkit` to the UI smoke test workflow to ensure all necessary system libraries are present for both browsers.

> Generated by [Update PR Body](https://github.com/elastic/ai-github-actions-playground/actions/runs/22556519120) for issue #1097

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22556519120, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions-playground/actions/runs/22556519120 -->