### PR TITLE
fix: remove Object.values fallback in indicesUtils extractors

### DIFF
--- a/peek/src/components/indicesUtils.ts
+++ b/peek/src/components/indicesUtils.ts
@@ -39,9 +39,7 @@ export function extractMappingFields(
   mappingResponse: Record<string, unknown>,
   indexName: string,
 ): MappingField[] {
-  const indexData = (mappingResponse[indexName] ?? Object.values(mappingResponse)[0]) as
-    | Record<string, unknown>
-    | undefined;
+  const indexData = mappingResponse[indexName] as Record<string, unknown> | undefined;
   if (!indexData) return [];
   const mappings = indexData.mappings as Record<string, unknown> | undefined;
   if (!mappings) return [];
@@ -70,9 +68,7 @@ export function extractSettings(
   settingsResponse: Record<string, unknown>,
   indexName: string,
 ): Array<{ key: string; value: string }> {
-  const indexData = (settingsResponse[indexName] ?? Object.values(settingsResponse)[0]) as
-    | Record<string, unknown>
-    | undefined;
+  const indexData = settingsResponse[indexName] as Record<string, unknown> | undefined;
   if (!indexData) return [];
   const settings = indexData.settings as Record<string, unknown> | undefined;
   if (!settings) return [];


### PR DESCRIPTION
## Summary
- Removes the `Object.values(...)[0]` fallback in `extractMappingFields` and `extractSettings` in `indicesUtils.ts`
- Prevents returning data for a different index when the requested `indexName` key is missing

## Changes
- In `peek/src/components/indicesUtils.ts`, `extractMappingFields` now reads only `mappingResponse[indexName]`
- In `peek/src/components/indicesUtils.ts`, `extractSettings` now reads only `settingsResponse[indexName]`
- This fix restores the missing review feedback from PR #1083 that was not included in its squash merge

## Checklist
- [ ] Ran `make check` successfully (lint + unit tests + build)
- [ ] Included a screenshot if I made a UX change
- [ ] Updated documentation if applicable

> Generated by [Update PR Body](https://github.com/elastic/ai-github-actions-playground/actions/runs/22559088168) for issue #1105

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22559088168, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions-playground/actions/runs/22559088168 -->