### PR TITLE
fix: convert ES|QL named params to array format for _query API

### DIFF
--- a/peek/src/services/es/client.ts
+++ b/peek/src/services/es/client.ts
@@ -352,13 +352,23 @@ export class ElasticsearchClient {
     signal?: AbortSignal,
   ): Promise<EsqlQueryResponse & { executionTimeMs: number }> {
     const start = Date.now();
+    // The ES|QL _query API expects named params as an array of single-key
+    // objects (e.g. [{"_tstart":"…"}, {"_tend":"…"}]).  Internally we build
+    // params as a plain object for ergonomics, so convert here at the
+    // serialisation boundary.
+    const body: Record<string, unknown> = { ...params };
+    if (body.params && !Array.isArray(body.params)) {
+      body.params = Object.entries(body.params as Record<string, unknown>).map(([k, v]) => ({
+        [k]: v,
+      }));
+    }
     const data = await this._fetchValidated<EsqlQueryResponse>(
       "/_query?format=json",
       esqlQueryResponseSchema,
       "ES|QL query",
       {
         method: "POST",
-        body: JSON.stringify(params),
+        body: JSON.stringify(body),
         signal,
       },
     );

--- a/peek/tests/unit/elasticsearchClient.test.ts
+++ b/peek/tests/unit/elasticsearchClient.test.ts
@@ -110,6 +110,39 @@ describe("request construction", () => {
     });
   });
 
+  it("query() converts object params to array of single-key objects", async () => {
+    const fetchSpy = mockFetchOnce({ columns: [], values: [] });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const client = makeClient();
+    await client.query({
+      query: "FROM logs-* | WHERE @timestamp >= ?_tstart AND @timestamp <= ?_tend",
+      params: { _tstart: "2025-01-01T00:00:00Z", _tend: "2025-01-02T00:00:00Z" },
+    });
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.params).toEqual([
+      { _tstart: "2025-01-01T00:00:00Z" },
+      { _tend: "2025-01-02T00:00:00Z" },
+    ]);
+  });
+
+  it("query() leaves array params untouched", async () => {
+    const fetchSpy = mockFetchOnce({ columns: [], values: [] });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const client = makeClient();
+    await client.query({
+      query: "FROM logs-* | LIMIT ?",
+      params: [10],
+    } as never);
+
+    const [, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    const body = JSON.parse(init.body as string);
+    expect(body.params).toEqual([10]);
+  });
+
   it("getClusterInfo() GETs /", async () => {
     const fetchSpy = mockFetchOnce({ cluster_name: "test" });
     vi.stubGlobal("fetch", fetchSpy);


### PR DESCRIPTION
## Summary
- The ES|QL `_query` API expects named parameters as an array of single-key objects (e.g. `[{"_tstart":"…"}, {"_tend":"…"}]`), not a flat object
- PR #1091 changed the internal params representation to a flat object **and** sent it as-is to Elasticsearch, breaking all parameterised queries (dashboards, explore page, traces, etc.)
- This fix converts object params to the required array format at the serialisation boundary in `client.query()`, keeping the ergonomic internal object API intact

## Root cause
PR #1091 assumed ES 9.x switched to a dict format for named params based on [elastic/elasticsearch#118168](https://github.com/elastic/elasticsearch/issues/118168), but that issue is still open — the API still requires the array format.

## What's fixed
All ES|QL queries that use named parameters (`?_tstart`, `?_tend`, `?service`, etc.) were sending:
```json
{"params": {"_tstart": "2025-01-01", "_tend": "2025-01-02"}}
```
Now correctly sends:
```json
{"params": [{"_tstart": "2025-01-01"}, {"_tend": "2025-01-02"}]}
```

## Test plan
- [x] Added 2 new unit tests verifying object-to-array conversion and array passthrough
- [x] All 52 client tests pass
- [x] All 1494 passing tests still pass (4 pre-existing failures in persesEsqlDatasource due to localStorage mock issue)
- [ ] Verify on demo site that dashboard queries, explore page, and trace queries work again

🤖 Generated with [Claude Code](https://claude.com/claude-code)