### PR TITLE
fix: ready-prs bot detection and CI kick for stale commits

### DIFF
--- a/scripts/ready-prs.py
+++ b/scripts/ready-prs.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import shutil
 import subprocess
 import sys
@@ -342,6 +343,7 @@ def phase_kick_ci(prs: list[PRInfo], runs: list[dict], ctx: Ctx) -> int:
             except RuntimeError:
                 pass  # Fall through to empty commit
         # No CI run exists for the current head — push an empty commit to trigger one.
+        os.makedirs("/tmp/gh-aw/agent", exist_ok=True)
         tmpdir = tempfile.mkdtemp(prefix=f"kick_ci_{pr.number}_", dir="/tmp/gh-aw/agent")
         try:
             subprocess.run(


### PR DESCRIPTION
## Summary

- **Bot detection was completely broken** — `gh pr list --json author` returns `app/copilot-swe-agent` and `app/github-actions`, not the `[bot]` suffix format the regex expected. Every bot PR was classified as "HUMAN" and skipped.
- **CI kick had no fallback** — when the "Address PR Review Feedback" workflow pushes new commits, the old CI run is on a stale sha. The script tried to re-run it but couldn't find a matching run, and just printed a warning.

## Changes

1. Replace `BOT_RE` regex with the `author.is_bot` field from the GitHub API — more reliable and future-proof
2. Push an empty commit as fallback when no CI run exists for the current head sha
3. Filter re-run candidates by `headSha` match (not just branch name) to avoid re-running stale CI

## Test plan

- [x] `python3 -m py_compile scripts/ready-prs.py` — no syntax errors
- [x] `--status-only` correctly classifies all 7 open PRs as bot-authored
- [x] `--dry-run` shows correct actions for all phases
- [x] Live run: pushed empty commits on 3 PRs (#1146, #1158, #1168), all now show CI PENDING

🤖 Generated with [Claude Code](https://claude.com/claude-code)