### PR TITLE
fix: repair broken unit tests for AddDataPage and TracesPage

### DIFF
--- a/peek/tests/component/AddDataPage.test.tsx
+++ b/peek/tests/component/AddDataPage.test.tsx
@@ -42,7 +42,11 @@ function renderPage() {
 }
 
 function getCommandValue(): string {
-  return (screen.getByLabelText("Starter command") as HTMLTextAreaElement).value;
+  // Legacy single-field UI uses a labelled textarea; new progressive-steps UI
+  // renders commands inside the tabpanel (step titles + <pre> blocks).
+  const label = screen.queryByLabelText("Starter command") as HTMLTextAreaElement | null;
+  if (label) return label.value;
+  return screen.getByRole("tabpanel").textContent ?? "";
 }
 
 const defaultCapabilities: UserCapabilities = {
@@ -287,7 +291,7 @@ describe("AddDataPage", () => {
     useConnectionStore.setState({ capabilities: defaultCapabilities });
     renderPage();
     await waitFor(() => {
-      expect(screen.getByLabelText("Starter command")).toBeInTheDocument();
+      expect(screen.getByRole("tabpanel")).toBeInTheDocument();
     });
     // No probe should be triggered since derivedOtlpUrl is null for non-Cloud URLs
     expect(fetchSpy).not.toHaveBeenCalledWith(
@@ -296,28 +300,30 @@ describe("AddDataPage", () => {
     );
   });
 
-  it("renders the Verify ingestion button", () => {
+  it("renders the Check now button", () => {
     renderPage();
-    expect(screen.getByRole("button", { name: /Verify ingestion/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /Check now/i })).toBeInTheDocument();
   });
 
-  it("disables Verify ingestion when there is no connection", () => {
+  it("disables Check now when there is no connection", () => {
     resetAllStores();
     useConnectionStore.setState({ capabilities: defaultCapabilities });
     renderPage();
-    expect(screen.getByRole("button", { name: /Verify ingestion/i })).toBeDisabled();
+    expect(screen.getByRole("button", { name: /Check now/i })).toBeDisabled();
   });
 
   it("shows success with navigation buttons when telemetry data streams are found", async () => {
-    mockGetDataStreams.mockResolvedValueOnce({
-      data_streams: [
-        { name: "metrics-host.otel-default" },
-        { name: "traces-generic.otel-default" },
-      ],
-    });
+    mockGetDataStreams
+      .mockResolvedValueOnce({ data_streams: [] }) // mount-time existing-data check
+      .mockResolvedValueOnce({
+        data_streams: [
+          { name: "metrics-host.otel-default" },
+          { name: "traces-generic.otel-default" },
+        ],
+      });
     const user = userEvent.setup();
     renderPage();
-    await user.click(screen.getByRole("button", { name: /Verify ingestion/i }));
+    await user.click(screen.getByRole("button", { name: /Check now/i }));
     await waitFor(() => {
       expect(screen.getByText(/Telemetry data detected/)).toBeInTheDocument();
     });
@@ -330,7 +336,7 @@ describe("AddDataPage", () => {
     mockGetDataStreams.mockResolvedValueOnce({ data_streams: [] });
     const user = userEvent.setup();
     renderPage();
-    await user.click(screen.getByRole("button", { name: /Verify ingestion/i }));
+    await user.click(screen.getByRole("button", { name: /Check now/i }));
     await waitFor(() => {
       expect(screen.getByText(/No telemetry data streams found yet/)).toBeInTheDocument();
     });
@@ -338,23 +344,27 @@ describe("AddDataPage", () => {
   });
 
   it("shows error when verification fails", async () => {
-    mockGetDataStreams.mockRejectedValueOnce(new Error("Connection refused"));
+    mockGetDataStreams
+      .mockResolvedValueOnce({ data_streams: [] }) // mount-time existing-data check
+      .mockRejectedValueOnce(new Error("Connection refused"));
     const user = userEvent.setup();
     renderPage();
-    await user.click(screen.getByRole("button", { name: /Verify ingestion/i }));
+    await user.click(screen.getByRole("button", { name: /Check now/i }));
     await waitFor(() => {
       expect(screen.getByText(/Connection refused/)).toBeInTheDocument();
     });
   });
 
   it("resets verification results when the connection changes", async () => {
-    mockGetDataStreams.mockResolvedValueOnce({
-      data_streams: [{ name: "metrics-host.otel-default" }],
-    });
+    mockGetDataStreams
+      .mockResolvedValueOnce({ data_streams: [] }) // mount-time existing-data check
+      .mockResolvedValueOnce({
+        data_streams: [{ name: "metrics-host.otel-default" }],
+      });
     const user = userEvent.setup();
     renderPage();
 
-    await user.click(screen.getByRole("button", { name: /Verify ingestion/i }));
+    await user.click(screen.getByRole("button", { name: /Check now/i }));
     await waitFor(() => {
       expect(screen.getByText(/Telemetry data detected/)).toBeInTheDocument();
     });

--- a/peek/tests/component/TracesPage.test.tsx
+++ b/peek/tests/component/TracesPage.test.tsx
@@ -226,7 +226,9 @@ describe("TracesPage auto-run on quick filter changes", () => {
     const user = userEvent.setup();
     render(
       <MemoryRouter>
-        <TracesPage />
+        <NuqsTestingAdapter hasMemory>
+          <TracesPage />
+        </NuqsTestingAdapter>
       </MemoryRouter>,
     );
 
@@ -337,7 +339,9 @@ describe("TracesPage duration parsing", () => {
   it("falls back to nanosecond duration when microsecond field is missing", () => {
     render(
       <MemoryRouter>
-        <TracesPage />
+        <NuqsTestingAdapter hasMemory>
+          <TracesPage />
+        </NuqsTestingAdapter>
       </MemoryRouter>,
     );
 


### PR DESCRIPTION
## Summary

- Update AddDataPage test assertions from "Verify ingestion" to "Check now" to match the renamed CTA button
- Update `getCommandValue()` helper to work with the new progressive command steps UI that renders commands in the tabpanel instead of a single `<TextField>`
- Account for mount-time `detectTelemetrySignals` call that consumes mock responses before click handlers run (3 verification tests)
- Wrap two TracesPage test renders with `NuqsTestingAdapter` to provide the required nuqs framework adapter

## Test plan

- [x] All 42 AddDataPage tests pass (was 17 failing)
- [x] All 13 TracesPage tests pass (was 2 failing)
- [x] ESLint pre-commit hook passes

Closes #1311

🤖 Generated with [Claude Code](https://claude.com/claude-code)