### PR TITLE
fix: fail smoke test check when tests or preflight fail

### DIFF
--- a/.github/workflows/ui-smoke-test-pr-review.yml
+++ b/.github/workflows/ui-smoke-test-pr-review.yml
@@ -333,3 +333,9 @@ jobs:
               });
               core.info("Created new PR comment");
             }
+
+      - name: Fail if smoke tests or preflight failed
+        if: steps.smoke.outcome == 'failure' || steps.preflight.outcome == 'failure'
+        run: |
+          echo "::error::Smoke tests or screenshot preflight failed — see PR comment for details."
+          exit 1


### PR DESCRIPTION
## Summary

- Add a final gate step to `ui-smoke-test-pr-review.yml` that fails the GitHub check when smoke tests or screenshot preflight fail
- The `smoke` and `preflight` steps use `continue-on-error: true` so the PR comment is always posted with results, but previously the job always reported success regardless of test outcome
- Now the check will show as failed in PR status, blocking merge when smoke tests break

## Test plan

- [ ] Open a PR that breaks smoke tests and verify the check fails
- [ ] Open a PR where smoke tests pass and verify the check succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)