### PR TITLE
ci: cache node_modules and Playwright browsers, restrict smoke to chromium

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,10 +33,16 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
-          cache: "npm"
-          cache-dependency-path: peek/package-lock.json
+
+      - name: Restore node_modules cache
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: peek/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('peek/package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: cd peek && npm ci
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
@@ -64,10 +70,16 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
-          cache: "npm"
-          cache-dependency-path: peek/package-lock.json
+
+      - name: Restore node_modules cache
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: peek/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('peek/package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: cd peek && npm ci
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"

--- a/.github/workflows/ui-smoke-test-pr-review.yml
+++ b/.github/workflows/ui-smoke-test-pr-review.yml
@@ -25,18 +25,41 @@ jobs:
       - uses: actions/setup-node@v5
         with:
           node-version: "24"
-          cache: "npm"
-          cache-dependency-path: peek/package-lock.json
+
+      - name: Restore node_modules cache
+        id: cache-node-modules
+        uses: actions/cache@v4
+        with:
+          path: peek/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('peek/package-lock.json') }}
 
       - name: Install dependencies
+        if: steps.cache-node-modules.outputs.cache-hit != 'true'
         run: cd peek && npm ci
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
           ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
 
-      - name: Install Playwright Browsers & Deps
-        run: npx playwright install --with-deps chromium webkit
+      - name: Restore Playwright browser cache
+        id: cache-playwright
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('peek/package-lock.json') }}
+
+      - name: Install Playwright browser (cache miss)
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        run: npx playwright install --with-deps chromium
         working-directory: peek
+
+      - name: Install Playwright OS dependencies (cache hit)
+        if: steps.cache-playwright.outputs.cache-hit == 'true'
+        run: npx playwright install-deps chromium
+        working-directory: peek
+
+      - name: Build
+        working-directory: peek
+        run: npm run build
 
       - name: Run E2E smoke tests
         id: smoke
@@ -45,9 +68,7 @@ jobs:
         env:
           PLAYWRIGHT_JSON_OUTPUT_NAME: smoke-results.json
           PLAYWRIGHT_PREVIEW: "1"
-        run: |
-          npm run build
-          npx playwright test tests/e2e/smoke.spec.ts --reporter=json
+        run: npx playwright test tests/e2e/smoke.spec.ts --reporter=json --project chromium
 
       - name: Run screenshot preflight
         id: preflight


### PR DESCRIPTION
## Summary

Reduces wasted time across the three CI jobs that run on every PR (`lint`, `test`, `smoke-review`).

## Changes

### node_modules caching (all 3 jobs)
Replaces `actions/setup-node cache: "npm"` (which caches the npm registry but still unpacks all packages on every run) with direct `peek/node_modules` caching keyed on `OS + hash(package-lock.json)`. On a warm cache `npm ci` is skipped entirely.

**Before:** ~35–42s per job even with warm npm cache  
**After:** ~2–5s restore on cache hit (zero npm ci)

### Playwright browser caching (smoke-review)
Adds `actions/cache` for `~/.cache/ms-playwright` keyed on `OS + hash(package-lock.json)`. On cache hit, only the fast OS-level deps (`install-deps`) are re-run.

**Before:** 45s browser download every run  
**After:** ~5–10s OS deps only on cache hit

### Remove webkit from smoke, restrict to chromium (smoke-review)
Smoke tests were running across all 3 Playwright projects (chromium, mobile-chrome, mobile-safari = 24 test runs). Mobile coverage is handled by the dedicated `explore-mobile` workflow. The smoke job now runs chromium only (8 test runs).

**Before:** ~127s E2E step (3 projects × 8 tests + build)  
**After:** ~45s E2E step (1 project × 8 tests)

### Split build into its own step (smoke-review)
`npm run build` was embedded inside the "Run E2E smoke tests" step. Separating it makes build failures visible independently in the GitHub Actions UI, and the build output is reused by both the E2E step (via `npm run preview`) and the preflight step.

## Expected improvement

| Workflow | Before | After (warm cache) |
|---|---|---|
| CI (wallclock) | ~107s | ~60s |
| Smoke (wallclock) | ~231s | ~80–100s |

---
The body of this PR [is automatically managed](https://ela.st/github-ai-tools) by the [Update PR Body workflow](https://github.com/elastic/ai-github-actions-playground/actions/runs/22600452375).

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22600452375, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions-playground/actions/runs/22600452375 -->