### PR TITLE
fix(test): increase testTimeout to 15s to prevent CI flakes on slow runners

### DIFF
--- a/peek/vitest.config.ts
+++ b/peek/vitest.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     // Files that need jsdom opt in with a `// @vitest-environment jsdom` comment.
     environmentMatchGlobs: [["tests/unit/**/*.test.ts", "node"]],
     setupFiles: ["./vitest.setup.ts"],
+    testTimeout: 15000,
     css: false,
     coverage: {
       provider: "v8",


### PR DESCRIPTION
## Problem

The `cancels edit details without saving changes` test in `DashboardsLandingPage.test.tsx` is timing out on CI with the default 5000ms vitest timeout.

The test passes locally (1143ms) but the CI runner is heavily loaded — collect phase alone took 259s vs ~3s locally (~80× slower). With that slowdown, any test involving multiple userEvent interactions can exceed 5s.

## Fix

Set `testTimeout: 15000` in `vitest.config.ts`. This is still well within a reasonable budget while giving enough headroom for loaded runners.

Closes the CI failure introduced by #1377.