### PR TITLE
fix(smoke): use .first() to disambiguate duplicate Search Traces button

### DIFF
--- a/peek/tests/e2e/smoke.spec.ts
+++ b/peek/tests/e2e/smoke.spec.ts
@@ -299,7 +299,7 @@ test.describe("smoke – site navigation", () => {
   }) => {
     await connectToMockCluster(page);
     await navigateViaSidebar(page, "Traces");
-    await page.getByRole("button", { name: "Search Traces" }).click();
+    await page.getByRole("button", { name: "Search Traces" }).first().click();
     await expect(page.getByText("1 traces found")).toBeVisible();
     await page.getByText("GET /checkout").click();
     await expect(page.getByText("2 spans")).toBeVisible();


### PR DESCRIPTION
## Problem

`TraceResultsView` renders a "Search Traces" button in its empty state at the same time as the primary "Search Traces" button in `TraceSearchPanel`. Both are visible on initial page load, so Playwright strict mode rejects the locator with *strict mode violation: getByRole('button', { name: 'Search Traces' }) resolved to 2 elements*.

## Fix

Use `.first()` on the locator to target the toolbar button (which renders before the results area).

```ts
// before
await page.getByRole("button", { name: "Search Traces" }).click();
// after
await page.getByRole("button", { name: "Search Traces" }).first().click();
```