### PR TITLE
fix(test): hold StorageMock refs to survive vi.unstubAllGlobals() in afterEach

### DIFF
--- a/peek/vitest.setup.ts
+++ b/peek/vitest.setup.ts
@@ -49,13 +49,15 @@ class StorageMock implements Storage {
   }
 }
 
-vi.stubGlobal("localStorage", new StorageMock());
-vi.stubGlobal("sessionStorage", new StorageMock());
+const localStorageMock = new StorageMock();
+const sessionStorageMock = new StorageMock();
+vi.stubGlobal("localStorage", localStorageMock);
+vi.stubGlobal("sessionStorage", sessionStorageMock);
 
 afterEach(() => {
   cleanup();
-  localStorage.clear();
-  sessionStorage.clear();
+  localStorageMock.clear();
+  sessionStorageMock.clear();
 });
 
 vi.mock("echarts/core", () => ({


### PR DESCRIPTION
## Problem

`persesEsqlDatasource.test.ts` calls `vi.unstubAllGlobals()` in its own `afterEach` (to clean up a `fetch` stub). This runs before the shared `afterEach` in `vitest.setup.ts`, which then calls `localStorage.clear()` — but `localStorage` has been restored to its pre-stub value and no longer has a `.clear()` method.

```
TypeError: localStorage.clear is not a function
 ❯ vitest.setup.ts:57:16
```

4 tests in `persesEsqlDatasource.test.ts` were failing.

## Fix

Hold direct references to the `StorageMock` instances in `vitest.setup.ts` and call `.clear()` on them rather than accessing the globals by name. The references are always valid regardless of what `vi.unstubAllGlobals()` does.