### PR TITLE
fix: restore wizard AddDataPage and integrate useIngestionVerification

### DIFF
--- a/peek/src/components/AddDataPage.tsx
+++ b/peek/src/components/AddDataPage.tsx
@@ -33,20 +33,113 @@ import {
   PLATFORM_GUIDES,
   SIGNAL_NAV,
 } from "../utils/addDataUtils";
-import type { EndpointType, Platform, TelemetrySignal } from "../utils/addDataUtils";
+import type {
+  AddDataSuccessCta,
+  EndpointType,
+  Platform,
+  TelemetrySignal,
+} from "../utils/addDataUtils";
 
 import PageHeader from "./PageHeader";
 
-const SIGNAL_PREFIXES: TelemetrySignal[] = ["logs", "metrics", "traces"];
+type WizardStep = 1 | 2 | 3 | 4 | 5;
+type TechnologyCategory =
+  | "Cloud"
+  | "Containers"
+  | "Databases"
+  | "Applications"
+  | "Operating Systems"
+  | "Network";
 
-// ---------------------------------------------------------------------------
-// Component
-// ---------------------------------------------------------------------------
+interface TechnologyOption {
+  id: string;
+  name: string;
+  category: TechnologyCategory;
+  summary: string;
+  expectedSignals: TelemetrySignal[];
+  defaultPlatform: Platform;
+}
+
+const TECHNOLOGY_OPTIONS: TechnologyOption[] = [
+  {
+    id: "kubernetes",
+    name: "Kubernetes",
+    category: "Containers",
+    summary: "Collect cluster, node, and workload telemetry.",
+    expectedSignals: ["metrics", "logs", "traces"],
+    defaultPlatform: "kubernetes",
+  },
+  {
+    id: "docker",
+    name: "Docker",
+    category: "Containers",
+    summary: "Collect container and host telemetry with Docker Compose.",
+    expectedSignals: ["metrics", "logs"],
+    defaultPlatform: "docker",
+  },
+  {
+    id: "linux-host",
+    name: "Linux Host",
+    category: "Operating Systems",
+    summary: "Install EDOT Collector on Linux hosts/VMs.",
+    expectedSignals: ["metrics", "logs"],
+    defaultPlatform: "linux",
+  },
+  {
+    id: "windows-host",
+    name: "Windows Host",
+    category: "Operating Systems",
+    summary: "Install EDOT Collector on Windows hosts/VMs.",
+    expectedSignals: ["metrics", "logs"],
+    defaultPlatform: "windows",
+  },
+  {
+    id: "postgresql",
+    name: "PostgreSQL",
+    category: "Databases",
+    summary: "Capture query performance and resource telemetry.",
+    expectedSignals: ["metrics", "logs"],
+    defaultPlatform: "linux",
+  },
+  {
+    id: "nginx",
+    name: "Nginx",
+    category: "Applications",
+    summary: "Capture request logs and latency metrics.",
+    expectedSignals: ["logs", "metrics"],
+    defaultPlatform: "linux",
+  },
+];
+
+const RECOMMENDED_TECHNOLOGY_IDS = ["kubernetes", "docker", "linux-host"];
+const CATEGORIES: Array<"All" | TechnologyCategory> = [
+  "All",
+  "Cloud",
+  "Containers",
+  "Databases",
+  "Applications",
+  "Operating Systems",
+  "Network",
+];
+
+const STEP_TITLES: Record<WizardStep, string> = {
+  1: "What are you monitoring?",
+  2: "Select your environment",
+  3: "Install and configure",
+  4: "Validate data receipt",
+  5: "Explore your data + next steps",
+};
 
 export default function AddDataPage() {
   const navigate = useNavigate();
   const connection = useConnectionStore((s) => s.connection);
   const capabilities = useConnectionStore((s) => s.capabilities);
+
+  const [wizardStep, setWizardStep] = useState<WizardStep>(1);
+  const [selectedTechnology, setSelectedTechnology] = useState<TechnologyOption | null>(null);
+  const [technologySearch, setTechnologySearch] = useState("");
+  const [activeCategory, setActiveCategory] = useState<"All" | TechnologyCategory>("All");
+
   const [platform, setPlatform] = useState<Platform>("kubernetes");
   const [endpointType, setEndpointType] = useState<EndpointType>("elasticsearch");
   const [copied, setCopied] = useState(false);
@@ -56,7 +149,6 @@ export default function AddDataPage() {
 
   const [clusterVersion, setClusterVersion] = useState<string | null>(null);
   const endpointTypeManuallySetRef = useRef(false);
-  /** `null` = not yet probed, `true` = reachable, `false` = unreachable */
   const [ingestAvailable, setIngestAvailable] = useState<boolean | null>(null);
 
   const apiKeyResult = useAddDataApiKey();
@@ -64,7 +156,6 @@ export default function AddDataPage() {
   const apiKeyValue = apiKeyResult.status === "success" ? apiKeyResult.data : null;
   const apiKeyError = apiKeyResult.status === "error" ? apiKeyResult.error : null;
 
-  // Fetch cluster version on mount so commands use the matching EDOT version
   useEffect(() => {
     if (!connection) return;
     let cancelled = false;
@@ -75,7 +166,7 @@ export default function AddDataPage() {
         if (!cancelled) setClusterVersion(info.version.number);
       })
       .catch(() => {
-        /* best-effort; commands will fall back to placeholder */
+        /* best effort */
       });
     return () => {
       cancelled = true;
@@ -83,26 +174,23 @@ export default function AddDataPage() {
   }, [connection]);
 
   const esUrl = connection?.url ?? "<YOUR_ELASTICSEARCH_ENDPOINT>";
-  const ingestUrl = connection?.ingestUrl?.trim();
   const ingestCandidates = useMemo(
-    () => (ingestUrl ? [ingestUrl] : deriveIngestCandidates(esUrl)),
-    [ingestUrl, esUrl],
+    () =>
+      connection?.ingestUrl?.trim() ? [connection.ingestUrl.trim()] : deriveIngestCandidates(esUrl),
+    [connection, esUrl],
   );
-  const ingestCandidatesKey = useMemo(() => ingestCandidates.join("|"), [ingestCandidates]);
+  const ingestCandidatesKey = ingestCandidates.join(",");
   const [derivedOtlpUrl, setDerivedOtlpUrl] = useState<string | null>(null);
-  const probeTargetOtlpUrl = derivedOtlpUrl ?? ingestCandidates[0] ?? null;
-  const otlpUrl = derivedOtlpUrl ?? "<YOUR_OTLP_ENDPOINT>";
-
-  // Reset derived OTLP state when ingest candidates change — use a derived
-  // key comparison to avoid calling setState inside an effect synchronously.
-  const [prevCandidatesKey, setPrevCandidatesKey] = useState(ingestCandidatesKey);
-  if (ingestCandidatesKey !== prevCandidatesKey) {
-    setPrevCandidatesKey(ingestCandidatesKey);
+  const [prevIngestCandidatesKey, setPrevIngestCandidatesKey] = useState(ingestCandidatesKey);
+  // Adjust derived state when ingest candidates change (during render, not in an effect)
+  if (ingestCandidatesKey !== prevIngestCandidatesKey) {
+    setPrevIngestCandidatesKey(ingestCandidatesKey);
     setDerivedOtlpUrl(null);
     setIngestAvailable(null);
   }
+  const probeTargetOtlpUrl = derivedOtlpUrl ?? ingestCandidates[0] ?? null;
+  const otlpUrl = derivedOtlpUrl ?? "<YOUR_OTLP_ENDPOINT>";
 
-  // Probe the derived OTLP ingest endpoint; auto-select OTLP when reachable
   useEffect(() => {
     if (ingestCandidates.length === 0) return;
     let cancelled = false;
@@ -110,7 +198,6 @@ export default function AddDataPage() {
     (async () => {
       let firstReachable: string | null = null;
       for (const candidate of ingestCandidates) {
-        // Probe each candidate in order and use the first reachable endpoint.
         const available = await probeOtlpEndpoint(candidate);
         if (cancelled) return;
         if (available) {
@@ -128,6 +215,7 @@ export default function AddDataPage() {
       cancelled = true;
     };
   }, [ingestCandidates]);
+
   const version = clusterVersion ?? "<VERSION>";
   const apiKey = apiKeyValue ?? "<YOUR_API_KEY>";
   const hasEndpoint =
@@ -135,7 +223,6 @@ export default function AddDataPage() {
   const prefilledCount = [apiKeyValue, hasEndpoint, clusterVersion].filter(Boolean).length;
   const activeGuide = useMemo(() => PLATFORM_GUIDES[platform], [platform]);
 
-  // ---- Progressive command steps ----
   const fullCommand = useMemo(
     () => activeGuide.command({ esUrl, version, apiKey, endpointType, otlpUrl }),
     [activeGuide, esUrl, version, apiKey, endpointType, otlpUrl],
@@ -169,7 +256,6 @@ export default function AddDataPage() {
     scheduleCopyFeedbackReset();
   }, [apiKeyValue, scheduleCopyFeedbackReset]);
 
-  // ---- Context-aware banner: detect existing data on load ----
   const [existingSignals, setExistingSignals] = useState<Set<TelemetrySignal> | null>(null);
   useEffect(() => {
     if (!connection) return;
@@ -180,7 +266,7 @@ export default function AddDataPage() {
         if (!cancelled) setExistingSignals(signals);
       })
       .catch(() => {
-        /* best-effort */
+        /* best effort */
       });
     return () => {
       cancelled = true;
@@ -198,121 +284,299 @@ export default function AddDataPage() {
     }
   }, [connection, apiKeyValue, verifyStatus, startPolling]);
 
+  const selectedSignals = selectedTechnology?.expectedSignals ?? [];
+  const signalExpectation =
+    selectedSignals.length > 1
+      ? `${selectedSignals.slice(0, -1).join(", ")} and ${selectedSignals[selectedSignals.length - 1]}`
+      : (selectedSignals[0] ?? "telemetry");
+
+  const expectedButMissingSignals = selectedSignals.filter((signal) => !foundSignals.has(signal));
+  const foundExpectedSignals = selectedSignals.filter((signal) => foundSignals.has(signal));
+
+  const recommendedTechnologies = useMemo(
+    () => TECHNOLOGY_OPTIONS.filter((tech) => RECOMMENDED_TECHNOLOGY_IDS.includes(tech.id)),
+    [],
+  );
+
+  const filteredTechnologies = useMemo(() => {
+    const query = technologySearch.trim().toLowerCase();
+    return TECHNOLOGY_OPTIONS.filter((tech) => {
+      const categoryMatches = activeCategory === "All" || tech.category === activeCategory;
+      const queryMatches =
+        query.length === 0 ||
+        tech.name.toLowerCase().includes(query) ||
+        tech.summary.toLowerCase().includes(query);
+      return categoryMatches && queryMatches;
+    });
+  }, [activeCategory, technologySearch]);
+
+  const outcomeSignals: TelemetrySignal[] =
+    foundSignals.size > 0
+      ? (Array.from(foundSignals).sort() as TelemetrySignal[])
+      : selectedSignals;
+  const outcomeSignalsKey = outcomeSignals.join(",");
+
+  const outcomeCtas = useMemo(() => {
+    const ctas: AddDataSuccessCta[] = [];
+    for (const signal of outcomeSignals) {
+      ctas.push(...SIGNAL_NAV[signal].successCtas);
+    }
+    if (ctas.length === 0) {
+      ctas.push({ id: "additional_source", label: "Add another source", path: "/add-data" });
+    }
+    const unique = new Map<string, AddDataSuccessCta>();
+    for (const cta of ctas) {
+      unique.set(`${cta.id}:${cta.path}`, cta);
+    }
+    return Array.from(unique.values());
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [outcomeSignalsKey]);
+
+  const renderStepProgress = () => (
+    <Stack direction="row" spacing={1} flexWrap="wrap">
+      {(Object.keys(STEP_TITLES) as unknown as WizardStep[]).map((stepNumber) => (
+        <Chip
+          key={stepNumber}
+          label={`Step ${stepNumber}: ${STEP_TITLES[stepNumber]}`}
+          color={
+            stepNumber === wizardStep ? "primary" : stepNumber < wizardStep ? "success" : "default"
+          }
+          variant={stepNumber === wizardStep ? "filled" : "outlined"}
+          size="small"
+        />
+      ))}
+    </Stack>
+  );
+
   return (
     <Box sx={{ display: "flex", flexDirection: "column", gap: 1.5, height: "100%", minHeight: 0 }}>
       <Paper variant="outlined" sx={{ p: 1.5 }}>
         <PageHeader
           title="Add Data"
-          description="Set up the EDOT Collector (Elastic Distribution of OpenTelemetry Collector) to send logs, metrics, and traces to your Elasticsearch cluster."
+          description="Onboard a new telemetry source in five guided steps: choose technology, configure environment, install collector, verify ingestion, and explore next actions."
           actions={
             clusterVersion ? (
               <Chip label={`EDOT Collector v${clusterVersion}`} size="small" variant="outlined" />
             ) : undefined
           }
         />
+        <Box sx={{ mt: 1.5 }}>{renderStepProgress()}</Box>
       </Paper>
 
-      {/* Context-aware banner: existing data detected */}
       {existingSignals &&
         existingSignals.size > 0 &&
         (() => {
           const sorted = Array.from(existingSignals).sort();
           const label =
             sorted.length > 2
-              ? sorted.slice(0, -1).join(", ") + ", and " + sorted[sorted.length - 1]
+              ? `${sorted.slice(0, -1).join(", ")}, and ${sorted[sorted.length - 1]}`
               : sorted.join(" and ");
           return (
             <Alert severity="info">
-              You already have {label} data.{" "}
-              {sorted.map((s) => (
-                <Link
-                  key={s}
-                  component="button"
-                  variant="body2"
-                  onClick={() => navigate(SIGNAL_NAV[s].path)}
-                  sx={{ mx: 0.5 }}
-                >
-                  {SIGNAL_NAV[s].label}
-                </Link>
-              ))}
-              — Add more sources below.
+              You already have {label} data. {sorted.map((s) => SIGNAL_NAV[s].label).join(", ")} are
+              ready. Add another source below.
             </Alert>
           );
         })()}
 
-      <Paper variant="outlined" sx={{ display: "flex", flexDirection: "column", gap: 1.5, p: 1.5 }}>
-        <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
-          <Typography variant="body2">Endpoint type</Typography>
+      {wizardStep === 1 && (
+        <Paper
+          variant="outlined"
+          sx={{ display: "flex", flexDirection: "column", gap: 1.5, p: 1.5 }}
+        >
+          <Typography variant="h6">Step 1: What are you monitoring?</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Pick a technology to tailor environment choices, setup commands, verification checks,
+            and next actions.
+          </Typography>
+          <TextField
+            label="Search technologies"
+            value={technologySearch}
+            onChange={(e) => setTechnologySearch(e.target.value)}
+            fullWidth
+          />
           <ToggleButtonGroup
-            value={endpointType}
+            value={activeCategory}
             exclusive
             size="small"
-            onChange={(_, value: EndpointType | null) => {
-              if (value) {
-                endpointTypeManuallySetRef.current = true;
-                setEndpointType(value);
-              }
+            onChange={(_, value: "All" | TechnologyCategory | null) => {
+              if (value) setActiveCategory(value);
             }}
-            aria-label="Endpoint type"
+            aria-label="Technology category"
           >
-            <ToggleButton value="elasticsearch">Elasticsearch</ToggleButton>
-            <ToggleButton value="managed_otlp">Managed OTLP</ToggleButton>
+            {CATEGORIES.map((category) => (
+              <ToggleButton key={category} value={category}>
+                {category}
+              </ToggleButton>
+            ))}
           </ToggleButtonGroup>
-        </Stack>
-        {endpointType === "managed_otlp" && probeTargetOtlpUrl && (
-          <Alert
-            severity={ingestAvailable ? "success" : ingestAvailable === false ? "warning" : "info"}
-          >
-            {ingestAvailable === null
-              ? `Checking OTLP endpoint availability at ${probeTargetOtlpUrl}…`
-              : ingestAvailable
-                ? `OTLP endpoint verified at ${probeTargetOtlpUrl}`
-                : `Could not reach OTLP endpoint at ${probeTargetOtlpUrl} — verify the URL is correct`}
-          </Alert>
-        )}
-        {endpointType === "managed_otlp" && !probeTargetOtlpUrl && (
-          <Alert severity="info">
-            Enter your managed OTLP endpoint. For Elastic Cloud, it follows the pattern
-            https://&lt;id&gt;.ingest.&lt;region&gt;.&lt;provider&gt;.elastic.cloud
-          </Alert>
-        )}
 
-        <Tabs
-          value={platform}
-          onChange={(_, value: Platform) => setPlatform(value)}
-          variant="scrollable"
-          scrollButtons="auto"
-          sx={{ minHeight: 36, "& .MuiTab-root": { minHeight: 36, py: 0.5 } }}
-        >
-          <Tab value="kubernetes" label="Kubernetes" />
-          <Tab value="docker" label="Docker" />
-          <Tab value="linux" label="Linux" />
-          <Tab value="macos" label="macOS" />
-          <Tab value="windows" label="Windows" />
-        </Tabs>
-
-        <Box role="tabpanel">
-          <Stack direction="row" spacing={1} alignItems="center">
-            <Typography variant="body2" sx={{ flex: 1 }}>
-              {activeGuide.label} quickstart
+          <Stack spacing={1}>
+            <Typography variant="body2" sx={{ fontWeight: 600 }}>
+              Recommended for you
             </Typography>
-            <Button size="small" variant="outlined" onClick={() => void handleCopyAll()}>
-              {copied ? "Copied!" : "Copy all"}
-            </Button>
-            <Button
-              size="small"
-              variant="outlined"
-              href={activeGuide.quickstartUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              endIcon={<OpenInNewIcon fontSize="small" />}
-            >
-              Open official docs
-            </Button>
+            <Stack direction="row" spacing={1} flexWrap="wrap">
+              {recommendedTechnologies.map((tech) => (
+                <Button
+                  key={tech.id}
+                  size="small"
+                  variant={selectedTechnology?.id === tech.id ? "contained" : "outlined"}
+                  onClick={() => {
+                    setSelectedTechnology(tech);
+                    setPlatform(tech.defaultPlatform);
+                  }}
+                >
+                  {tech.name}
+                </Button>
+              ))}
+            </Stack>
           </Stack>
 
-          {/* Progressive command steps */}
-          {commandSteps.length > 0 ? (
+          <Stack spacing={1}>
+            {filteredTechnologies.map((tech) => (
+              <Paper key={tech.id} variant="outlined" sx={{ p: 1 }}>
+                <Stack
+                  direction="row"
+                  justifyContent="space-between"
+                  alignItems="center"
+                  spacing={1}
+                >
+                  <Box>
+                    <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                      {tech.name}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {tech.category} • {tech.summary}
+                    </Typography>
+                  </Box>
+                  <Button
+                    size="small"
+                    variant={selectedTechnology?.id === tech.id ? "contained" : "outlined"}
+                    onClick={() => {
+                      setSelectedTechnology(tech);
+                      setPlatform(tech.defaultPlatform);
+                    }}
+                  >
+                    {selectedTechnology?.id === tech.id ? "Selected" : "Choose"}
+                  </Button>
+                </Stack>
+              </Paper>
+            ))}
+          </Stack>
+
+          <Stack direction="row" justifyContent="flex-end">
+            <Button
+              variant="contained"
+              onClick={() => setWizardStep(2)}
+              disabled={selectedTechnology === null}
+            >
+              Continue to step 2
+            </Button>
+          </Stack>
+        </Paper>
+      )}
+
+      {wizardStep === 2 && (
+        <Paper
+          variant="outlined"
+          sx={{ display: "flex", flexDirection: "column", gap: 1.5, p: 1.5 }}
+        >
+          <Typography variant="h6">Step 2: Select your environment</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {selectedTechnology
+              ? `${selectedTechnology.name} can emit ${signalExpectation}.`
+              : "Choose endpoint and platform options for your deployment."}
+          </Typography>
+
+          <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
+            <Typography variant="body2">Endpoint type</Typography>
+            <ToggleButtonGroup
+              value={endpointType}
+              exclusive
+              size="small"
+              onChange={(_, value: EndpointType | null) => {
+                if (value) {
+                  endpointTypeManuallySetRef.current = true;
+                  setEndpointType(value);
+                }
+              }}
+              aria-label="Endpoint type"
+            >
+              <ToggleButton value="elasticsearch">Elasticsearch</ToggleButton>
+              <ToggleButton value="managed_otlp">Managed OTLP</ToggleButton>
+            </ToggleButtonGroup>
+          </Stack>
+
+          {endpointType === "managed_otlp" && probeTargetOtlpUrl && (
+            <Alert
+              severity={
+                ingestAvailable ? "success" : ingestAvailable === false ? "warning" : "info"
+              }
+            >
+              {ingestAvailable === null
+                ? `Checking OTLP endpoint availability at ${probeTargetOtlpUrl}…`
+                : ingestAvailable
+                  ? `OTLP endpoint verified at ${probeTargetOtlpUrl}`
+                  : `Could not reach OTLP endpoint at ${probeTargetOtlpUrl} — verify the URL is correct`}
+            </Alert>
+          )}
+
+          <Tabs
+            value={platform}
+            onChange={(_, value: Platform) => setPlatform(value)}
+            variant="scrollable"
+            scrollButtons="auto"
+            sx={{ minHeight: 36, "& .MuiTab-root": { minHeight: 36, py: 0.5 } }}
+          >
+            <Tab value="kubernetes" label="Kubernetes" />
+            <Tab value="docker" label="Docker" />
+            <Tab value="linux" label="Linux" />
+            <Tab value="macos" label="macOS" />
+            <Tab value="windows" label="Windows" />
+          </Tabs>
+
+          <Stack direction="row" justifyContent="space-between">
+            <Button variant="outlined" onClick={() => setWizardStep(1)}>
+              Back
+            </Button>
+            <Button variant="contained" onClick={() => setWizardStep(3)}>
+              Continue to step 3
+            </Button>
+          </Stack>
+        </Paper>
+      )}
+
+      {wizardStep === 3 && (
+        <Paper
+          variant="outlined"
+          sx={{ display: "flex", flexDirection: "column", gap: 1.5, p: 1.5 }}
+        >
+          <Typography variant="h6">Step 3: Install and configure</Typography>
+          <Typography variant="body2" color="text.secondary">
+            Use the generated {activeGuide.label} quickstart commands for{" "}
+            {selectedTechnology?.name ?? "your source"}.
+          </Typography>
+
+          <Box role="tabpanel">
+            <Stack direction="row" spacing={1} alignItems="center">
+              <Typography variant="body2" sx={{ flex: 1 }}>
+                {activeGuide.label} quickstart
+              </Typography>
+              <Button size="small" variant="outlined" onClick={() => void handleCopyAll()}>
+                {copied ? "Copied!" : "Copy all"}
+              </Button>
+              <Button
+                size="small"
+                variant="outlined"
+                href={activeGuide.quickstartUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                endIcon={<OpenInNewIcon fontSize="small" />}
+              >
+                Open official docs
+              </Button>
+            </Stack>
+
             <Stack spacing={1.5} sx={{ mt: 1.5 }}>
               {commandSteps.map((step, index) => (
                 <Paper key={index} variant="outlined" sx={{ p: 1.5 }}>
@@ -354,174 +618,228 @@ export default function AddDataPage() {
                 </Paper>
               ))}
             </Stack>
-          ) : (
-            <TextField
-              label="Starter command"
-              value={fullCommand}
-              multiline
-              minRows={7}
-              fullWidth
-              slotProps={{
-                input: { readOnly: true, sx: { fontFamily: "monospace", fontSize: "0.8rem" } },
-                inputLabel: { sx: { color: "text.primary" } },
-              }}
-            />
-          )}
 
-          <Alert severity="info" sx={{ mt: 1.5 }}>
-            {apiKeyValue
-              ? "Your generated API key" + (hasEndpoint || clusterVersion ? ", " : " ")
-              : "Generate an API key below (or provide your own) — "}
-            {endpointType === "managed_otlp" && derivedOtlpUrl
-              ? "OTLP endpoint, "
-              : connection?.url
-                ? "Elasticsearch endpoint, "
-                : ""}
-            {clusterVersion ? `and EDOT Collector v${clusterVersion} ` : ""}
-            {apiKeyValue ||
-            (endpointType === "managed_otlp"
-              ? Boolean(derivedOtlpUrl)
-              : Boolean(connection?.url)) ||
-            clusterVersion
-              ? (prefilledCount > 1 ? "have" : "has") + " been pre-filled in the command above."
-              : "Replace the placeholders before running."}
-            {!apiKeyValue && (
-              <>
-                {" "}
-                Replace <code>&lt;YOUR_API_KEY&gt;</code> with a generated or existing key.
-              </>
-            )}
-          </Alert>
-        </Box>
-      </Paper>
+            <Alert severity="info" sx={{ mt: 1.5 }}>
+              {apiKeyValue
+                ? "Your generated API key" + (hasEndpoint || clusterVersion ? ", " : " ")
+                : "Generate an API key below (or provide your own) — "}
+              {endpointType === "managed_otlp" && derivedOtlpUrl
+                ? "OTLP endpoint, "
+                : connection?.url
+                  ? "Elasticsearch endpoint, "
+                  : ""}
+              {clusterVersion ? `and EDOT Collector v${clusterVersion} ` : ""}
+              {apiKeyValue ||
+              (endpointType === "managed_otlp"
+                ? Boolean(derivedOtlpUrl)
+                : Boolean(connection?.url)) ||
+              clusterVersion
+                ? (prefilledCount > 1 ? "have" : "has") + " been pre-filled in the command above."
+                : "Replace the placeholders before running."}
+              {!apiKeyValue && (
+                <>
+                  {" "}
+                  Replace <code>&lt;YOUR_API_KEY&gt;</code> with a generated or existing key.
+                </>
+              )}
+            </Alert>
+          </Box>
 
-      <Paper variant="outlined" sx={{ display: "flex", flexDirection: "column", gap: 1, p: 1.5 }}>
-        <Typography variant="body2">Collector credentials</Typography>
-        {apiKeyError && <Alert severity="error">{apiKeyError}</Alert>}
-        {capabilities?.canCreateApiKeys ? (
-          <>
-            <Stack direction="row" spacing={1} alignItems="center">
-              <Button
-                size="small"
-                variant="contained"
-                onClick={() => void apiKeyResult.createKey()}
-                disabled={creatingApiKey}
-              >
-                {creatingApiKey ? <CircularProgress size={16} /> : "Generate API key"}
-              </Button>
-              <Typography variant="body2" color="text.secondary">
-                Generates an API key for collector setup.
-              </Typography>
-            </Stack>
-            {apiKeyValue && (
-              <>
-                <Alert severity="warning">
-                  Copy this API key now. You will not be able to read it again after leaving this
-                  page.
-                </Alert>
-                <Stack direction="row" spacing={1} alignItems="center">
-                  <TextField
-                    size="small"
-                    fullWidth
-                    label="Base64 API key"
-                    value={apiKeyValue}
-                    slotProps={{ input: { readOnly: true } }}
-                  />
-                  <Button size="small" variant="outlined" onClick={() => void handleCopyApiKey()}>
-                    {copied ? "Copied" : "Copy"}
-                  </Button>
-                </Stack>
-              </>
-            )}
-          </>
-        ) : (
-          <Alert severity="warning">
-            Your credentials do not include API key creation privileges. Generate a key manually via{" "}
-            <Link
-              href="https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Create API key endpoint
-            </Link>{" "}
-            or ask an administrator to provision one for collector onboarding.
-          </Alert>
-        )}
-      </Paper>
-
-      <Paper variant="outlined" sx={{ display: "flex", flexDirection: "column", gap: 1, p: 1.5 }}>
-        <Typography variant="body2">Verify ingestion</Typography>
-        <Typography variant="body2" color="text.secondary">
-          After starting the collector, check whether telemetry data streams have appeared.
-        </Typography>
-        <Stack direction="row" spacing={1} alignItems="center">
-          <Button
-            size="small"
-            variant="contained"
-            onClick={() => void handleVerifyIngestion()}
-            disabled={!connection || verifyStatus === "checking" || verifyStatus === "polling"}
-            startIcon={
-              verifyStatus === "checking" || verifyStatus === "polling" ? (
-                <CircularProgress size={16} />
-              ) : (
-                <CheckCircleOutlineIcon fontSize="small" />
-              )
-            }
-          >
-            {verifyStatus === "checking" || verifyStatus === "polling" ? "Checking…" : "Check now"}
-          </Button>
-          {verifyStatus === "polling" && (
-            <Stack direction="row" spacing={0.5} alignItems="center">
-              <RadioButtonCheckedIcon
-                color="info"
-                sx={{
-                  animation: "pulse 1.5s ease-in-out infinite",
-                  fontSize: 16,
-                  "@keyframes pulse": {
-                    "0%, 100%": { opacity: 1 },
-                    "50%": { opacity: 0.3 },
-                  },
-                }}
-              />
-              <Typography variant="body2" color="info.main">
-                Listening for data…
-              </Typography>
-            </Stack>
-          )}
-        </Stack>
-        {verifyStatus === "error" && <Alert severity="error">{verifyError}</Alert>}
-        {(verifyStatus === "not_found" ||
-          (verifyStatus === "polling" && foundSignals.size === 0)) && (
-          <Alert severity="info">
-            No telemetry data streams found yet. Make sure the collector is running — we'll keep
-            checking automatically.{" "}
-            <Link
-              href="https://www.elastic.co/docs/solutions/observability/get-started/opentelemetry"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Troubleshooting docs
-            </Link>
-          </Alert>
-        )}
-        {verifyStatus === "found" && (
-          <Alert severity="success" icon={<CheckCircleOutlineIcon />}>
-            Telemetry data detected! Found data in: {Array.from(foundSignals).sort().join(", ")}.
-            <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
-              {SIGNAL_PREFIXES.filter((s) => foundSignals.has(s)).map((s) => (
+          <Typography variant="body2">Collector credentials</Typography>
+          {apiKeyError && <Alert severity="error">{apiKeyError}</Alert>}
+          {capabilities?.canCreateApiKeys ? (
+            <>
+              <Stack direction="row" spacing={1} alignItems="center">
                 <Button
-                  key={s}
                   size="small"
-                  variant="outlined"
-                  onClick={() => navigate(SIGNAL_NAV[s].path)}
+                  variant="contained"
+                  onClick={() => void apiKeyResult.createKey()}
+                  disabled={creatingApiKey}
                 >
-                  Go to {SIGNAL_NAV[s].label}
+                  {creatingApiKey ? <CircularProgress size={16} /> : "Generate API key"}
                 </Button>
-              ))}
-            </Stack>
-          </Alert>
-        )}
-      </Paper>
+                <Typography variant="body2" color="text.secondary">
+                  Generates an API key for collector setup.
+                </Typography>
+              </Stack>
+              {apiKeyValue && (
+                <>
+                  <Alert severity="warning">
+                    Copy this API key now. You will not be able to read it again after leaving this
+                    page.
+                  </Alert>
+                  <Stack direction="row" spacing={1} alignItems="center">
+                    <TextField
+                      size="small"
+                      fullWidth
+                      label="Base64 API key"
+                      value={apiKeyValue}
+                      slotProps={{ input: { readOnly: true } }}
+                    />
+                    <Button size="small" variant="outlined" onClick={() => void handleCopyApiKey()}>
+                      {copied ? "Copied" : "Copy"}
+                    </Button>
+                  </Stack>
+                </>
+              )}
+            </>
+          ) : (
+            <Alert severity="warning">
+              Your credentials do not include API key creation privileges. Generate a key manually
+              via{" "}
+              <Link
+                href="https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-security-create-api-key"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Create API key endpoint
+              </Link>{" "}
+              or ask an administrator to provision one for collector onboarding.
+            </Alert>
+          )}
+
+          <Stack direction="row" justifyContent="space-between">
+            <Button variant="outlined" onClick={() => setWizardStep(2)}>
+              Back
+            </Button>
+            <Button variant="contained" onClick={() => setWizardStep(4)}>
+              Continue to step 4
+            </Button>
+          </Stack>
+        </Paper>
+      )}
+
+      {wizardStep === 4 && (
+        <Paper variant="outlined" sx={{ display: "flex", flexDirection: "column", gap: 1, p: 1.5 }}>
+          <Typography variant="h6">Step 4: Validate data receipt</Typography>
+          <Typography variant="body2" color="text.secondary">
+            For {selectedTechnology?.name ?? "this integration"}, we expect to receive{" "}
+            {signalExpectation}.
+          </Typography>
+          <Stack direction="row" spacing={1} alignItems="center">
+            <Button
+              size="small"
+              variant="contained"
+              onClick={() => void handleVerifyIngestion()}
+              disabled={!connection || verifyStatus === "checking" || verifyStatus === "polling"}
+              startIcon={
+                verifyStatus === "checking" || verifyStatus === "polling" ? (
+                  <CircularProgress size={16} />
+                ) : (
+                  <CheckCircleOutlineIcon fontSize="small" />
+                )
+              }
+            >
+              {verifyStatus === "checking" || verifyStatus === "polling"
+                ? "Checking…"
+                : "Check now"}
+            </Button>
+            {verifyStatus === "polling" && (
+              <Stack direction="row" spacing={0.5} alignItems="center">
+                <RadioButtonCheckedIcon
+                  color="info"
+                  sx={{
+                    animation: "pulse 1.5s ease-in-out infinite",
+                    fontSize: 16,
+                    "@keyframes pulse": {
+                      "0%, 100%": { opacity: 1 },
+                      "50%": { opacity: 0.3 },
+                    },
+                  }}
+                />
+                <Typography variant="body2" color="info.main">
+                  Listening for data…
+                </Typography>
+              </Stack>
+            )}
+          </Stack>
+
+          {verifyStatus === "error" && <Alert severity="error">{verifyError}</Alert>}
+
+          {(verifyStatus === "not_found" ||
+            (verifyStatus === "polling" && foundSignals.size === 0)) && (
+            <Alert severity="info">
+              No telemetry data streams found yet. Make sure the collector is running — we&apos;ll
+              keep checking automatically.{" "}
+              <Link
+                href="https://www.elastic.co/docs/solutions/observability/get-started/opentelemetry"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Troubleshooting docs
+              </Link>
+            </Alert>
+          )}
+
+          {verifyStatus === "found" && (
+            <Alert severity="success" icon={<CheckCircleOutlineIcon />}>
+              Telemetry data detected! Found: {Array.from(foundSignals).sort().join(", ")}.
+              {expectedButMissingSignals.length > 0 && (
+                <Box sx={{ mt: 1 }}>
+                  <Typography variant="body2" sx={{ fontWeight: 600 }}>
+                    Partial success
+                  </Typography>
+                  <Typography variant="body2">
+                    We found {foundExpectedSignals.join(", ") || "telemetry"}, but still missing{" "}
+                    {expectedButMissingSignals.join(", ")} for{" "}
+                    {selectedTechnology?.name ?? "this source"}.
+                  </Typography>
+                </Box>
+              )}
+            </Alert>
+          )}
+
+          <Stack direction="row" justifyContent="space-between">
+            <Button variant="outlined" onClick={() => setWizardStep(3)}>
+              Back
+            </Button>
+            <Button variant="contained" onClick={() => setWizardStep(5)}>
+              Continue to step 5
+            </Button>
+          </Stack>
+        </Paper>
+      )}
+
+      {wizardStep === 5 && (
+        <Paper
+          variant="outlined"
+          sx={{ display: "flex", flexDirection: "column", gap: 1.5, p: 1.5 }}
+        >
+          <Typography variant="h6">Step 5: Explore your data + next steps</Typography>
+          <Typography variant="body2" color="text.secondary">
+            {selectedTechnology?.name ?? "Your source"} is configured. Choose a next action to
+            explore dashboards, set up alerting, or onboard another source.
+          </Typography>
+          {outcomeSignals.length > 0 && (
+            <Alert severity="success">
+              Ready signals: {outcomeSignals.map((signal) => SIGNAL_NAV[signal].label).join(", ")}.
+            </Alert>
+          )}
+          <Stack direction="row" spacing={1} flexWrap="wrap">
+            {outcomeCtas.map((cta) => (
+              <Button
+                key={`${cta.id}:${cta.path}`}
+                size="small"
+                variant={cta.id === "signal" ? "contained" : "outlined"}
+                onClick={() => {
+                  if (cta.id === "additional_source") {
+                    setWizardStep(1);
+                    return;
+                  }
+                  navigate(cta.path);
+                }}
+              >
+                {cta.label}
+              </Button>
+            ))}
+          </Stack>
+          <Stack direction="row" justifyContent="flex-start">
+            <Button variant="outlined" onClick={() => setWizardStep(4)}>
+              Back
+            </Button>
+          </Stack>
+        </Paper>
+      )}
     </Box>
   );
 }


### PR DESCRIPTION
## Problem

PR #1383 accidentally merged the non-wizard `AddDataPage.tsx` during conflict resolution, replacing the 5-step EDOT Collector setup wizard with the simpler single-page version. This broke 6 component tests that expect the wizard UI.

## Fix

- Restores the wizard version of `AddDataPage.tsx` from before the merge (commit `71e6db5a`)
- Integrates the `useIngestionVerification` hook from PR #1383, replacing the manual `setInterval`/`AbortController` polling state machine
- Fixes pre-existing lint issues in the wizard code:
  - Uses render-time state adjustment (prevIngestCandidatesKey pattern) instead of `setState` in an effect for the ingest candidates reset
  - Uses a stable `ingestCandidatesKey` string dep for the `outcomeCtas` `useMemo` to satisfy the React Compiler memoization analysis

## Tests

All 1721 unit tests pass.