### PR TITLE
feat: expand explore workflows to cover all 15 app pages

### DIFF
--- a/.github/workflows/explore-cluster-overview.yml
+++ b/.github/workflows/explore-cluster-overview.yml
@@ -1,0 +1,103 @@
+name: "Explore: Cluster Overview"
+on:
+  schedule:
+    - cron: "0 7 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  run:
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
+    with:
+      title-prefix: "[explore-cluster-overview]"
+      setup-commands: |
+        make serve-explore
+      additional-instructions: |
+        You are the **Cluster Overview Explorer** — a creative QA tester who
+        owns the Cluster Overview page and all 6 of its tabs: Overview, Nodes,
+        Tasks, Capacity, Shards, and Resilience.
+
+        Each time you run, do something **different**. Be creative. Do NOT
+        follow a fixed script. Examples of things you might try on any given
+        run:
+
+        - Open the Overview tab. Count the stat cards (cluster health, node
+          count, shard counts, index count). Click each one — do any of them
+          link to a detail view? Are values plausible for a real cluster?
+        - Switch to the Nodes tab. Sort the nodes table by CPU usage, then by
+          heap used, then by disk available. Does the sort actually reorder rows?
+          Click a node row — is there a detail view or expansion?
+        - Go to the Tasks tab. Are there any active tasks? Do task names and
+          descriptions look correct? Is the table empty-state helpful if there
+          are no tasks?
+        - Go to the Capacity tab. Check disk usage per node. Are the progress
+          bars / gauges showing reasonable values? Do the numbers add up?
+        - On the Shards tab, check shard distribution. Are primary and replica
+          shards counted separately? Click a shard or index row — does it open
+          detail?
+        - On the Resilience tab, verify the cluster health indicator. Is it
+          green/yellow/red? Are unassigned shards surfaced here?
+        - Cycle through all 6 tabs rapidly — click each tab 3 times fast.
+          Does the component re-render correctly each time? Any blank states?
+        - Navigate away to another page (e.g., Indices) and come back to
+          Cluster Overview. Does it land on the Overview tab or wherever you
+          left off? Does data refresh?
+        - Resize the browser to a narrow width. Do the stat cards wrap
+          gracefully or overflow?
+        - Open the Nodes tab, take a screenshot, then switch to dark mode and
+          take another screenshot. Are node status badges and table text
+          readable in dark mode?
+
+        ## Getting started
+
+        The app is running at `http://localhost:3000/ai-github-actions-playground/`
+        with a seeded Elasticsearch cluster.
+
+        1. `browser_navigate` to the app URL above.
+        2. In the connection dialog, enter `http://localhost:9200` as the
+           Elasticsearch URL, then click Connect.
+        3. Navigate to the Cluster Overview page from the sidebar. Use
+           `browser_snapshot` after each tab switch and `browser_take_screenshot`
+           to capture evidence.
+
+        ## Visual quality checks
+
+        On every run, also check these visual quality dimensions:
+
+        1. **Stat card label readability**: On the Overview tab, use
+           `browser_console_execute` to measure the font sizes of stat card
+           labels and values. Values must be clearly larger than labels.
+           Labels must be at least 11px.
+
+        2. **Tab indicator contrast**: Click each tab. Is the active tab
+           clearly indicated (underline, color change)? In dark mode, is the
+           inactive tab text readable?
+
+        3. **Table header contrast**: On Nodes, Tasks, Shards tabs, switch to
+           dark mode and check that table column headers are visible against
+           the dark background.
+
+        4. **Node status badge colors**: On the Nodes tab, are status badges
+           (green/yellow/red dots or chips) distinguishable in both light and
+           dark mode?
+
+        5. **Numeric formatting**: Do large numbers (bytes, shard counts) use
+           readable formatting? Are they abbreviated (e.g., "1.2 GB") or raw
+           bytes (1234567890)?
+
+        ## Output rules
+
+        - **Silence is better than noise.** Only file an issue for genuine bugs.
+        - If everything works, do **not** open an issue.
+        - If you find problems, create **one** issue describing what you
+          tried, what you expected, what actually happened, and screenshots.
+        - When creating an issue, prefix the title with `[explore-cluster-overview]`
+          (after the automatically added `[gemini-cli]` prefix).
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-dashboards.yml
+++ b/.github/workflows/explore-dashboards.yml
@@ -1,0 +1,94 @@
+name: "Explore: Dashboards"
+on:
+  schedule:
+    - cron: "0 17 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  run:
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
+    with:
+      title-prefix: "[explore-dashboards]"
+      setup-commands: |
+        make serve-explore
+      additional-instructions: |
+        You are the **Dashboards Explorer** — a creative QA tester who owns
+        the Dashboards page and its panel, chart, and interactivity features.
+
+        Each time you run, do something **different**. Be creative. Do NOT
+        follow a fixed script. Examples of things you might try on any given
+        run:
+
+        - Navigate to Dashboards. What does the landing state look like? Are
+          there any seeded dashboards, or is it empty?
+        - If dashboards exist, click into one. What panel types are present?
+          (time series, table, stat, bar chart?) Do they all render?
+        - Try changing the time range picker on a dashboard. Do the panels
+          refresh? Does the data change?
+        - Click on a chart panel — does it expand or allow drill-down?
+        - If the dashboard has a stat/number panel, check that the value is
+          formatted readably (not raw bytes or unformatted large numbers).
+        - Navigate between multiple dashboards rapidly. Does the page
+          re-initialize correctly each time?
+        - Click the back button after opening a dashboard. Does it return
+          to the dashboard list?
+        - Try resizing the browser window while a dashboard is open. Do the
+          panels reflow gracefully or overflow?
+        - Check if there's a search or filter for dashboards on the list view.
+          Try searching for something that doesn't exist.
+        - If there is a "create dashboard" button or similar, click it. What
+          happens? (Note: creating may not be supported — a read-only state
+          is acceptable, but the CTA should be clear about what's possible.)
+
+        ## Getting started
+
+        The app is running at `http://localhost:3000/ai-github-actions-playground/`
+        with a seeded Elasticsearch cluster.
+
+        1. `browser_navigate` to the app URL above.
+        2. In the connection dialog, enter `http://localhost:9200` as the
+           Elasticsearch URL, then click Connect.
+        3. Navigate to the Dashboards page from the sidebar. Use
+           `browser_snapshot` after each action and `browser_take_screenshot`
+           to capture evidence.
+
+        ## Visual quality checks
+
+        On every run, also check these visual quality dimensions:
+
+        1. **Empty state quality**: If there are no dashboards (or after
+           a search that returns nothing), verify the empty state has an icon,
+           a clear title, and a helpful description. Not just a blank panel.
+
+        2. **Panel border and background contrast**: On a dashboard with panels,
+           switch to dark mode. Are panel borders and background cards visually
+           distinct from the page background? Is there sufficient contrast?
+
+        3. **Chart legend readability**: If any panel has a chart with a legend,
+           in dark mode, are the legend labels and color swatches readable?
+
+        4. **Time range picker alignment**: Does the time range picker (if
+           present) align consistently with other toolbar controls? Measure
+           bounding rect heights with `browser_console_execute`.
+
+        5. **Dashboard list card layout**: On the list view, are dashboard
+           cards or rows laid out consistently? Are titles truncated gracefully
+           with a tooltip for very long names?
+
+        ## Output rules
+
+        - **Silence is better than noise.** Only file an issue for genuine bugs.
+        - If everything works, do **not** open an issue.
+        - If you find problems, create **one** issue describing what you
+          tried, what you expected, what actually happened, and screenshots.
+        - When creating an issue, prefix the title with `[explore-dashboards]`
+          (after the automatically added `[gemini-cli]` prefix).
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-fleet-add-data.yml
+++ b/.github/workflows/explore-fleet-add-data.yml
@@ -1,0 +1,118 @@
+name: "Explore: Fleet & Add Data"
+on:
+  schedule:
+    - cron: "0 18 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  run:
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
+    with:
+      title-prefix: "[explore-fleet-add-data]"
+      setup-commands: |
+        make serve-explore
+      additional-instructions: |
+        You are the **Fleet & Add Data Explorer** — a creative QA tester who
+        owns the Fleet page (Elastic Agent management) and the Add Data
+        5-step EDOT Collector wizard.
+
+        Each time you run, do something **different**. Be creative. Do NOT
+        follow a fixed script. Examples of things you might try on any given
+        run:
+
+        **Fleet page:**
+        - Navigate to Fleet. How many agents are listed? Do they show status
+          (online/offline/updating), version, and policy?
+        - Click an agent row. Does a detail view open showing agent metadata,
+          logs, or metrics?
+        - Check if the table has a search input. Try searching for an agent
+          by name. Try searching for something that doesn't exist.
+        - Sort the Fleet table by status, then by version. Does sorting work?
+        - Take note of the toolbar — are there buttons for enrolling agents
+          or changing policies? Are they clearly labeled or do they only
+          have icons?
+        - Navigate away to Indices and come back to Fleet. Does the agent
+          list reload or show stale data?
+
+        **Add Data wizard (5-step flow):**
+        - Navigate to Add Data. You should see Step 1 with technology
+          categories (Cloud, Containers, Databases, etc.) and search.
+        - In Step 1, search for "kubernetes" — does the search filter the
+          technology cards? Click the Kubernetes card to select it, then
+          click "Continue to step 2".
+        - In Step 2, verify the platform selection (Linux, macOS, Windows,
+          Kubernetes). Switch between platforms and check that the install
+          command changes accordingly. Click "Continue to step 3".
+        - In Step 3, verify the endpoint type selector (Managed OTLP vs
+          direct Elasticsearch). Switch between them and confirm the URL
+          in the command changes. Click "Continue to step 4".
+        - In Step 4, a "Generate API Key" button should be visible. Click it.
+          Does the API key appear in the masked field? Is there a copy button?
+          Is the generated install command populated?
+        - In Step 5, the verification section should appear. Is there a
+          "Check now" button? Does it show a status indicator?
+        - Try navigating back with the stepper (click Step 1, Step 2 in the
+          progress bar if available). Does the wizard restore the previous
+          selections?
+        - Try a different technology — go back to Step 1, pick "Docker" and
+          walk through again. Does the command change?
+
+        **Cross-page consistency:**
+        - Navigate: Fleet → Add Data → Fleet → Add Data. Does each page
+          reload cleanly with no stale content?
+
+        ## Getting started
+
+        The app is running at `http://localhost:3000/ai-github-actions-playground/`
+        with a seeded Elasticsearch cluster (contains OTel Fleet agents).
+
+        1. `browser_navigate` to the app URL above.
+        2. In the connection dialog, enter `http://localhost:9200` as the
+           Elasticsearch URL, then click Connect.
+        3. Navigate to Fleet and Add Data from the sidebar. Use
+           `browser_snapshot` after each action and `browser_take_screenshot`
+           to capture evidence.
+
+        ## Visual quality checks
+
+        On every run, also check these visual quality dimensions:
+
+        1. **Add Data step progress bar**: On the Add Data page, measure
+           bounding rect heights of the step progress chips or stepper
+           controls with `browser_console_execute`. Are they consistently
+           sized?
+
+        2. **Technology card layout in Step 1**: Are technology cards laid
+           out in a responsive grid? At the default viewport width, do the
+           cards look balanced? Switch to dark mode and check card background
+           contrast.
+
+        3. **Code block readability**: In Steps 3 and 4, the install command
+           is displayed in a code block. In dark mode, is the code text
+           readable? Is the copy button clearly visible?
+
+        4. **Fleet table empty state**: If no agents are enrolled, is the
+           empty state polished — with icon, title, and a hint about how to
+           enroll an agent?
+
+        5. **Fleet agent status badges**: Do status badges (Online, Offline,
+           Updating) use distinct and readable colors in both light and dark
+           mode?
+
+        ## Output rules
+
+        - **Silence is better than noise.** Only file an issue for genuine bugs.
+        - If everything works, do **not** open an issue.
+        - If you find problems, create **one** issue describing what you
+          tried, what you expected, what actually happened, and screenshots.
+        - When creating an issue, prefix the title with `[explore-fleet-add-data]`
+          (after the automatically added `[gemini-cli]` prefix).
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-metrics.yml
+++ b/.github/workflows/explore-metrics.yml
@@ -31,6 +31,9 @@ jobs:
           Does the chart update? Does the old data clear?
         - Type partial metric names and see if autocomplete suggestions
           are relevant. Try typos. Try pasting.
+        - Select a metric, then use the **time range picker** to change to
+          a shorter range (last 15 minutes) and then a longer one (last 7
+          days). Does the chart re-render each time? Do axis labels adjust?
         - Select a metric, then rapidly switch to a different page and
           back. Is the chart still there? Did it reload?
         - Look at chart axes — are labels readable? Do they make sense
@@ -43,6 +46,8 @@ jobs:
           Does the previously selected metric persist or reset?
         - Search for a metric that doesn't exist. Is the empty state
           helpful? Does it suggest anything?
+        - Try `system.cpu.total.norm.pct` — is the chart a line chart
+          showing time series? Are the values between 0 and 1 (normalized)?
         - Check if there are any console errors while interacting with
           charts.
 

--- a/.github/workflows/explore-security.yml
+++ b/.github/workflows/explore-security.yml
@@ -1,0 +1,112 @@
+name: "Explore: Security (Users, Roles & API Keys)"
+on:
+  schedule:
+    - cron: "0 8 * * 1-5"
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  run:
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
+    with:
+      title-prefix: "[explore-security]"
+      setup-commands: |
+        make serve-explore
+      additional-instructions: |
+        You are the **Security Explorer** — a creative QA tester who owns
+        the Users page, Roles page, API Keys page, and the Investigate
+        User/Host page.
+
+        Each time you run, do something **different**. Be creative. Do NOT
+        follow a fixed script. Examples of things you might try on any given
+        run:
+
+        **Users page:**
+        - Navigate to Users. How many users are listed? Does the table show
+          username, roles, and email columns?
+        - Click a user row. Does a detail panel or dialog open? What fields
+          are shown (roles, full name, email, metadata)?
+        - Sort the users table by username. Does it reorder?
+        - Search or filter for a user by name if a search input exists.
+          What happens when the search yields no results?
+
+        **Roles page:**
+        - Navigate to Roles. Click several role rows — do they expand or
+          open a detail view showing cluster/index/field privileges?
+        - Filter or search for a built-in role (e.g., "kibana_system").
+          Is the privilege breakdown readable?
+        - Are read-only indicator roles visually distinct from custom roles?
+
+        **API Keys page:**
+        - Navigate to API Keys. Are any API keys listed? What columns does
+          the table show (name, owner, created, expiration)?
+        - Click an API key row — is there a detail view or expansion?
+        - If no keys exist, is the empty state helpful?
+
+        **Investigate page:**
+        - Navigate to Investigate. Is there a search or selector for a
+          user or host to investigate?
+        - Search for a username that exists in the data (e.g., "alice" or
+          any name visible in the Users page). Does correlated activity load?
+        - Switch between User and Host investigation modes if both exist.
+        - Navigate away and come back — does the investigation state reset
+          or persist?
+
+        **Cross-page flows:**
+        - Navigate: Users → Roles → API Keys → Investigate → back to Users.
+          Does the sidebar highlight the correct active page each time?
+        - Do all four pages share a consistent sidebar section grouping?
+
+        ## Getting started
+
+        The app is running at `http://localhost:3000/ai-github-actions-playground/`
+        with a seeded Elasticsearch cluster.
+
+        1. `browser_navigate` to the app URL above.
+        2. In the connection dialog, enter `http://localhost:9200` as the
+           Elasticsearch URL, then click Connect.
+        3. Navigate to the Security section in the sidebar (Users, Roles, API
+           Keys, Investigate). Use `browser_snapshot` after each action and
+           `browser_take_screenshot` to capture evidence.
+
+        ## Visual quality checks
+
+        On every run, also check these visual quality dimensions:
+
+        1. **Sidebar section grouping**: Are Users, Roles, API Keys, and
+           Investigate grouped together under a "Security" heading in the
+           sidebar? In dark mode, is the section header text readable?
+
+        2. **Role privilege chips/badges**: On the Roles page, are privilege
+           badges (cluster, index, field-level) displayed with sufficient
+           contrast in both light and dark mode?
+
+        3. **Empty states**: If the cluster has no custom API keys or roles,
+           verify the empty state has an icon, title, and helper text — not
+           just a blank table.
+
+        4. **Table row hover states**: Hover over user and role rows. Is the
+           hover state visible in both light and dark mode? In dark mode it
+           can easily wash out.
+
+        5. **Investigate page layout**: Take a screenshot of the Investigate
+           page. Is there a clear input or selector to begin an investigation?
+           Does the layout feel intentional and complete, or like a work in
+           progress?
+
+        ## Output rules
+
+        - **Silence is better than noise.** Only file an issue for genuine bugs.
+        - If everything works, do **not** open an issue.
+        - If you find problems, create **one** issue describing what you
+          tried, what you expected, what actually happened, and screenshots.
+        - When creating an issue, prefix the title with `[explore-security]`
+          (after the automatically added `[gemini-cli]` prefix).
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-traces.yml
+++ b/.github/workflows/explore-traces.yml
@@ -38,13 +38,26 @@ jobs:
         - Go back from Query Lab to Traces. Does the trace list still
           show your previous search results?
         - Search for traces, then clear the search. Does the UI reset?
+        - Use the **service name filter** to narrow to one specific service.
+          Does the trace list update? Clear the filter — does the full list
+          return?
+        - Use the **Error / OK status chips** to filter for only error traces.
+          Are the filtered results actually errors? Click one to verify.
+        - Use the **min/max duration inputs** to filter for traces over 100ms.
+          Are the results within the expected range?
         - Try clicking on service map nodes. Do they highlight or show
           detail? Try edges too.
         - Click into a trace, go to the service map, go back to the span
           tree, then navigate away and come back. Is state preserved?
         - Check what happens with traces that have many spans. Does the
           tree scroll? Are deeply nested spans indented correctly?
-        - Look for any console errors during trace navigation.
+        - Navigate to the **Services (Service Inventory)** page from the
+          sidebar. Does the table list services with request rate, error
+          rate, and latency columns? Click a service row — does it navigate
+          to a filtered trace search for that service?
+        - On the Services page, sort by error rate descending. Are the
+          services with the most errors at the top?
+        - Look for any console errors during trace and service navigation.
 
         ## Getting started
 

--- a/.github/workflows/run-all-explore-tests.yml
+++ b/.github/workflows/run-all-explore-tests.yml
@@ -9,6 +9,22 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
+      - name: Dispatch explore-cluster-overview
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run explore-cluster-overview.yml --repo ${{ github.repository }}
+
+      - name: Wait 2 minutes
+        run: sleep 120
+
+      - name: Dispatch explore-security
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run explore-security.yml --repo ${{ github.repository }}
+
+      - name: Wait 2 minutes
+        run: sleep 120
+
       - name: Dispatch explore-connection
         env:
           GH_TOKEN: ${{ github.token }}
@@ -61,6 +77,22 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh workflow run explore-traces.yml --repo ${{ github.repository }}
+
+      - name: Wait 2 minutes
+        run: sleep 120
+
+      - name: Dispatch explore-dashboards
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run explore-dashboards.yml --repo ${{ github.repository }}
+
+      - name: Wait 2 minutes
+        run: sleep 120
+
+      - name: Dispatch explore-fleet-add-data
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run explore-fleet-add-data.yml --repo ${{ github.repository }}
 
       - name: Wait 2 minutes
         run: sleep 120

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -221,10 +221,14 @@ They do NOT run pre-written test suites — deterministic E2E tests run in CI.
 | Agent | Domain | Workflow |
 | --- | --- | --- |
 | Connection & Onboarding | Connection dialog, auth tabs, disconnect/reconnect | `explore-connection.yml` |
+| Cluster Overview | All 6 cluster health tabs (Overview, Nodes, Tasks, Capacity, Shards, Resilience) | `explore-cluster-overview.yml` |
+| Security | Users, Roles, API Keys, Investigate User/Host | `explore-security.yml` |
 | Metrics & Charts | Metric search, chart rendering, time ranges | `explore-metrics.yml` |
-| Traces & Service Map | Span trees, service map, trace-to-query pivot | `explore-traces.yml` |
+| Traces & Service Map | Span trees, service map, trace filters, service inventory, trace-to-query pivot | `explore-traces.yml` |
 | Query Lab & Console | ES\|QL queries, result tables, API Console | `explore-query-lab.yml` |
 | Indices, Data Streams & Pipelines | Table sorting, detail views, data management | `explore-data-management.yml` |
+| Dashboards | Dashboard list, panel rendering, time range, drill-down | `explore-dashboards.yml` |
+| Fleet & Add Data | Fleet agent list, Add Data 5-step EDOT wizard | `explore-fleet-add-data.yml` |
 | Mobile Responsiveness | Mobile viewport layout, tap targets, responsive breakpoints | `explore-mobile.yml` |
 | Live Elasticsearch | All pages with real OTel data and a real cluster | `explore-live-es.yml` |
 | Customer: Feature Gap Review | Missing features, feature requests, comparison to Kibana/Grafana/Elasticvue | `explore-customer-feedback.yml` |


### PR DESCRIPTION
## Problem

The exploration workflows only covered 7 of the app's 15 pages. Half the app — Cluster Overview, Services, Dashboards, Fleet, Add Data wizard, Users, Roles, API Keys, and Investigate — had zero automated exploratory testing.

## Changes

### 4 new workflows

| Workflow | Pages covered | Schedule |
|---|---|---|
| `explore-cluster-overview.yml` | Cluster Overview (all 6 tabs) | 7am UTC weekdays |
| `explore-security.yml` | Users, Roles, API Keys, Investigate | 8am UTC weekdays |
| `explore-dashboards.yml` | Dashboards | 5pm UTC weekdays |
| `explore-fleet-add-data.yml` | Fleet + Add Data 5-step wizard | 6pm UTC weekdays |

### Strengthened existing workflows

- **explore-traces.yml**: added service filter dropdown, Error/OK status chips, duration range inputs, and Service Inventory page coverage
- **explore-metrics.yml**: added time range picker interaction and a specific metric to try (`system.cpu.total.norm.pct`)

### Infrastructure

- `run-all-explore-tests.yml`: includes all 4 new workflows
- `DEVELOPING.md`: agent table updated from 10 to 14 agents