### PR TITLE
refactor(nav): restructure navigation into Data, Workspace, and System groups

### DIFF
--- a/peek/src/routes/manifest.ts
+++ b/peek/src/routes/manifest.ts
@@ -56,7 +56,7 @@ const ProfilingPage = lazy(() => import("../components/profiling/ProfilingPage")
 const InvestigatePage = lazy(() => import("../components/InvestigatePage"));
 const UsersPage = lazy(() => import("../components/UsersPage"));
 
-export type NavGroup = "Workspace" | "Security" | "System" | "Help" | "Settings";
+export type NavGroup = "Data" | "Workspace" | "Security" | "System" | "Help" | "Settings";
 
 export interface PageConfig {
   path: string;
@@ -99,7 +99,7 @@ export const PAGE_MANIFEST = {
     skeletonVariant: "table",
     nav: {
       label: "Query Lab",
-      group: "Workspace",
+      group: "Data",
       order: 20,
       showInSidebar: true,
       icon: createElement(SearchIcon, { fontSize: "small" }),
@@ -113,8 +113,8 @@ export const PAGE_MANIFEST = {
     skeletonVariant: "table",
     nav: {
       label: "Logs",
-      group: "Workspace",
-      order: 25,
+      group: "Data",
+      order: 30,
       showInSidebar: true,
       icon: createElement(SubjectIcon, { fontSize: "small" }),
     },
@@ -127,8 +127,8 @@ export const PAGE_MANIFEST = {
     skeletonVariant: "chart",
     nav: {
       label: "Metrics",
-      group: "Workspace",
-      order: 30,
+      group: "Data",
+      order: 40,
       showInSidebar: true,
       icon: createElement(ExploreIcon, { fontSize: "small" }),
     },
@@ -141,8 +141,8 @@ export const PAGE_MANIFEST = {
     skeletonVariant: "table",
     nav: {
       label: "Traces",
-      group: "Workspace",
-      order: 40,
+      group: "Data",
+      order: 50,
       showInSidebar: true,
       icon: createElement(TimelineIcon, { fontSize: "small" }),
     },
@@ -155,8 +155,8 @@ export const PAGE_MANIFEST = {
     skeletonVariant: "chart",
     nav: {
       label: "Profiling",
-      group: "Workspace",
-      order: 45,
+      group: "Data",
+      order: 60,
       showInSidebar: true,
       icon: createElement(SpeedIcon, { fontSize: "small" }),
     },
@@ -170,7 +170,7 @@ export const PAGE_MANIFEST = {
     nav: {
       label: "Services",
       group: "Workspace",
-      order: 35,
+      order: 20,
       showInSidebar: true,
       icon: createElement(MiscellaneousServicesIcon, { fontSize: "small" }),
     },
@@ -182,7 +182,7 @@ export const PAGE_MANIFEST = {
     showTimeControls: false,
     nav: {
       label: "Console",
-      group: "Workspace",
+      group: "System",
       order: 50,
       showInSidebar: true,
       icon: createElement(TerminalIcon, { fontSize: "small" }),
@@ -208,7 +208,7 @@ export const PAGE_MANIFEST = {
     showTimeControls: false,
     skeletonVariant: "cards",
     nav: {
-      label: "Cluster Overview",
+      label: "Overview",
       group: "System",
       order: 10,
       showInSidebar: true,
@@ -222,7 +222,7 @@ export const PAGE_MANIFEST = {
     showTimeControls: false,
     skeletonVariant: "cards",
     nav: {
-      label: "Cluster Health",
+      label: "Health",
       group: "System",
       order: 11,
       showInSidebar: true,
@@ -236,7 +236,7 @@ export const PAGE_MANIFEST = {
     showTimeControls: false,
     skeletonVariant: "table",
     nav: {
-      label: "Cluster Tasks",
+      label: "Tasks",
       group: "System",
       order: 12,
       showInSidebar: false,
@@ -250,7 +250,7 @@ export const PAGE_MANIFEST = {
     showTimeControls: false,
     skeletonVariant: "cards",
     nav: {
-      label: "Cluster Capacity",
+      label: "Capacity",
       group: "System",
       order: 13,
       showInSidebar: false,
@@ -264,7 +264,7 @@ export const PAGE_MANIFEST = {
     showTimeControls: false,
     skeletonVariant: "table",
     nav: {
-      label: "Cluster Shards",
+      label: "Shards",
       group: "System",
       order: 14,
       showInSidebar: false,
@@ -278,9 +278,9 @@ export const PAGE_MANIFEST = {
     showTimeControls: false,
     skeletonVariant: "table",
     nav: {
-      label: "Cluster Resilience",
+      label: "Resilience",
       group: "System",
-      order: 15.5,
+      order: 15,
       showInSidebar: false,
       icon: createElement(ShieldIcon, { fontSize: "small" }),
     },
@@ -293,8 +293,8 @@ export const PAGE_MANIFEST = {
     skeletonVariant: "list",
     nav: {
       label: "Add Data",
-      group: "Workspace",
-      order: 5,
+      group: "Data",
+      order: 10,
       showInSidebar: true,
       icon: createElement(RocketLaunchIcon, { fontSize: "small" }),
     },
@@ -459,4 +459,4 @@ export const PAGE_MANIFEST = {
 export type PageId = keyof typeof PAGE_MANIFEST;
 
 /** Sidebar section display order. Sections not listed here won't appear. */
-export const NAV_SECTION_ORDER: NavGroup[] = ["Workspace", "Security", "System", "Help"];
+export const NAV_SECTION_ORDER: NavGroup[] = ["Data", "Workspace", "Security", "System", "Help"];

--- a/peek/tests/component/AppSidebar.test.tsx
+++ b/peek/tests/component/AppSidebar.test.tsx
@@ -39,6 +39,7 @@ describe("AppSidebar", () => {
   it("renders all section headings", () => {
     renderSidebar();
 
+    expect(screen.getByText("Data")).toBeInTheDocument();
     expect(screen.getByText("Workspace")).toBeInTheDocument();
     expect(screen.getByText("System")).toBeInTheDocument();
     expect(screen.getByText("Help")).toBeInTheDocument();
@@ -102,11 +103,11 @@ describe("AppSidebar", () => {
       "aria-disabled",
       "true",
     );
-    expect(screen.getByRole("button", { name: /cluster overview/i })).not.toHaveAttribute(
+    expect(screen.getByRole("button", { name: /^overview$/i })).not.toHaveAttribute(
       "aria-disabled",
       "true",
     );
-    expect(screen.getByRole("button", { name: /cluster health/i })).not.toHaveAttribute(
+    expect(screen.getByRole("button", { name: /^health$/i })).not.toHaveAttribute(
       "aria-disabled",
       "true",
     );
@@ -166,7 +167,7 @@ describe("AppSidebar", () => {
     const user = userEvent.setup();
     renderSidebar();
 
-    await user.click(screen.getByRole("button", { name: /cluster overview/i }));
+    await user.click(screen.getByRole("button", { name: /^overview$/i }));
 
     expect(screen.getByTestId("location")).toHaveTextContent("/cluster-overview");
   });
@@ -176,7 +177,7 @@ describe("AppSidebar", () => {
     const user = userEvent.setup();
     renderSidebar();
 
-    await user.click(screen.getByRole("button", { name: /cluster health/i }));
+    await user.click(screen.getByRole("button", { name: /^health$/i }));
 
     expect(screen.getByTestId("location")).toHaveTextContent("/cluster-health");
   });
@@ -185,10 +186,10 @@ describe("AppSidebar", () => {
     useConnectionStore.getState().setConnected(true);
     renderSidebar();
 
-    expect(screen.queryByRole("button", { name: /cluster tasks/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /cluster capacity/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /cluster shards/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole("button", { name: /cluster resilience/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^tasks$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^capacity$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^shards$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^resilience$/i })).not.toBeInTheDocument();
   });
 
   it("navigates to Fleet when clicked while connected", async () => {
@@ -250,6 +251,7 @@ describe("AppSidebar", () => {
       </MemoryRouter>,
     );
 
+    expect(screen.queryByText("Data")).not.toBeInTheDocument();
     expect(screen.queryByText("Workspace")).not.toBeInTheDocument();
     expect(screen.queryByText("System")).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /dashboards/i })).toBeInTheDocument();


### PR DESCRIPTION
## Summary

Revamps the application sidebar navigation to group pages by purpose rather than technology.

### Navigation Structure Changes

**New "Data" section** (previously scattered across Workspace):
- Add Data (order 10)
- Query Lab (order 20)
- Logs (order 30)
- Metrics (order 40)
- Traces (order 50)
- Profiling (order 60)

**"Workspace" section** now focused on saved/user content:
- Dashboards (order 10)
- Services (order 20)

**"System" section** — removed redundant "Cluster " prefix from all labels:
- Overview (was "Cluster Overview")
- Health (was "Cluster Health")
- Tasks (was "Cluster Tasks")
- Capacity (was "Cluster Capacity")
- Shards (was "Cluster Shards")
- Resilience (was "Cluster Resilience")
- Console (moved from Workspace → System, order 50)

**Section order:** Data → Workspace → Security → System → Help

### Why

The previous Workspace group mixed observability tools (Logs, Metrics, Traces), user workspaces (Dashboards), infra tools (Services, Console), and the entry point (Add Data) — with no clear organizing principle. The new structure groups by intent: Data = observe/query, Workspace = saved work, System = cluster management.

### Tests

- All 27 AppSidebar unit tests pass
- TypeScript type-checks cleanly
- No other components reference nav group strings (AppSidebar reads dynamically from `NAV_SECTION_ORDER`)