### PR TITLE
fix: chat stops after tool call — always set stopWhen for multi-step

### DIFF
--- a/peek/src/components/ChatPage.tsx
+++ b/peek/src/components/ChatPage.tsx
@@ -121,7 +121,7 @@ export default function ChatPage({ hideHeader = false }: { hideHeader?: boolean 
             { role: "user" as const, content: trimmed },
           ],
           tools,
-          ...(stopWhen ? { stopWhen } : {}),
+          stopWhen,
           abortSignal: controller.signal,
         });
 

--- a/peek/src/services/chatRuntime.ts
+++ b/peek/src/services/chatRuntime.ts
@@ -11,6 +11,11 @@ import { buildDetailedScreenContext } from "./screenContext";
 
 const CHAT_TIMEOUT_MS = 15_000;
 
+// Minimum steps to allow when only local tools are active.
+// Without this, AI SDK v6 stops after the first tool call and never generates
+// the follow-up text response (e.g. after get_screen_context → "Done" → silence).
+const LOCAL_TOOLS_MAX_STEPS = 5;
+
 interface ChatRuntimeArgs {
   config: LLMConfig;
   connection: ElasticsearchConnection | null;
@@ -35,7 +40,7 @@ export async function buildChatRuntime({
 }: ChatRuntimeArgs): Promise<{
   systemPrompt: string;
   tools: ToolSet;
-  stopWhen?: ReturnType<typeof stepCountIs>;
+  stopWhen: ReturnType<typeof stepCountIs>;
 }> {
   const localTools: ToolSet = {
     ...getLocalChatTools(connection),
@@ -64,6 +69,6 @@ export async function buildChatRuntime({
   return {
     systemPrompt,
     tools,
-    stopWhen: maxStepCountLimit > 0 ? stepCountIs(maxStepCountLimit) : undefined,
+    stopWhen: stepCountIs(maxStepCountLimit > 0 ? maxStepCountLimit : LOCAL_TOOLS_MAX_STEPS),
   };
 }


### PR DESCRIPTION
## Problem

The AI chat assistant was silently stopping after calling `get_screen_context` (or any tool). Users would see "Reading screen — Done" but never get a text response.

## Root Cause

In AI SDK v6, `streamText` requires `stopWhen` to be set to enable multi-step tool use. Without it, the SDK stops after the first tool-call step and never gives the model a chance to generate a follow-up text response.

Previously, `stopWhen` was only set when MCP tools were active (`maxStepCountLimit > 0`). When only local tools were active (the common case), `stopWhen` was `undefined`, silently disabling multi-step.

## Fix

Always pass `stopWhen` to `streamText`:
- When MCP tools are enabled: use their step count limit (unchanged)
- When only local tools are active: use `LOCAL_TOOLS_MAX_STEPS = 5`

Also removed the unnecessary conditional spread in `ChatPage.tsx` since `stopWhen` is now always defined.

## Testing

`cd peek && npx tsc --noEmit` — clean
