### PR TITLE
fix(traces): fix gantt chart layout overflow in trace detail panel

### DIFF
--- a/peek/src/components/traces/TraceDetailPanel.tsx
+++ b/peek/src/components/traces/TraceDetailPanel.tsx
@@ -69,7 +69,7 @@ export default function TraceDetailPanel({
           <ContentSkeleton variant="table" />
         </Box>
       ) : selectedTraceSpans.length > 0 ? (
-        <Box sx={{ flex: 1, overflow: "auto" }}>
+        <Box sx={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
           <TracingGanttChart key={selectedTraceId} options={GANTT_OPTIONS} trace={otlpTrace} />
         </Box>
       ) : (


### PR DESCRIPTION
## Summary
- Adds `minHeight: 0` to the chart wrapper `Box` so the flex child properly shrinks within the split pane layout
- Changes `overflow` from `"auto"` to `"hidden"` since the `TracingGanttChart` handles its own internal scrolling via Virtuoso — the outer `overflow: auto` was creating double scrollbars and a broken iframe-like appearance

The flex chain from `ResizableSplitPane` → bottom pane → `Paper` all correctly set `minHeight: 0` and `overflow: hidden`, but the innermost content `Box` wrapping the chart was missing both, breaking the height constraint propagation.

## Test plan
- [ ] Open Traces page, select a trace — gantt chart should fill the available space without double scrollbars
- [ ] Resize the split pane divider — chart should reflow correctly
- [ ] Verify span tree expand/collapse and minimap still work

---
The body of this PR [is automatically managed](https://ela.st/github-ai-tools) by the [Update PR Body workflow](https://github.com/elastic/ai-github-actions-playground/actions/runs/22628285738).

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22628285738, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions-playground/actions/runs/22628285738 -->