### PR TITLE
fix(tests): add sparkline test coverage to ServiceInventoryPage

### DIFF
--- a/peek/tests/component/ServiceInventoryPage.test.tsx
+++ b/peek/tests/component/ServiceInventoryPage.test.tsx
@@ -228,13 +228,15 @@ describe("ServiceInventoryPage", () => {
     await user.click(screen.getByRole("button", { name: "Search" }));
 
     await waitFor(() => {
-      const sparklineCall = mockRunQuery.mock.calls.find(([q]: [string]) => q.includes("BUCKET"));
-      expect(sparklineCall).toBeDefined();
-      const sparklineQuery = sparklineCall![0] as string;
-      expect(sparklineQuery).toContain("frontend");
-    })
+      expect(mockRunQuery.mock.calls.some(([q]: [string]) => q.includes("BUCKET"))).toBe(true);
+    });
+
+    const sparklineQuery = mockRunQuery.mock.calls.find(([q]: [string]) =>
+      q.includes("BUCKET"),
+    )![0] as string;
+    expect(sparklineQuery).toContain("frontend");
+    expect(sparklineQuery).toContain("backend-api");
     expect(sparklineQuery).toContain("payment-service");
-    expect(sparklineQuery).toContain("backend-api");;
   });
 
   it("navigates to Traces with a clean service filter when View Traces is clicked", async () => {


### PR DESCRIPTION
## Summary
- The `useEsqlQuery` mock in `ServiceInventoryPage.test.tsx` was returning inventory-shaped data for **all** queries, including sparkline queries
- `parseServiceSparklineData` received data without a `bucket` column → returned `{}` → `hasSparklines = false` → sparkline trend columns never rendered in tests
- The entire sparkline feature (added in #1576) had zero component-level test coverage

## Changes
- Updated the `useEsqlQuery` mock to detect sparkline queries (via `BUCKET` keyword) and return properly shaped sparkline data with time-bucketed values per service
- Added test: **"renders sparkline trend columns after search"** — verifies "Requests trend", "Latency trend", and "Error rate trend" column headers appear
- Added test: **"fires a sparkline query scoped to discovered services"** — verifies the sparkline query contains all 3 service names from the inventory results

## Test plan
- [x] All 10 `ServiceInventoryPage` tests pass (8 existing + 2 new)
- [x] Full suite: 2014 tests across 169 files pass
- [x] Pre-commit hooks (prettier + eslint) pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)