### PR TITLE
fix: propagate AbortSignal through ingestion query chain and split AddDataStepSetupProps

### DIFF
--- a/peek/src/components/addData/AddDataStepSetup.tsx
+++ b/peek/src/components/addData/AddDataStepSetup.tsx
@@ -28,12 +28,7 @@ import AwsDeployInstall from "./guides/AwsDeployInstall";
 import ApmInstall from "./guides/ApmInstall";
 import FluentBitInstall from "./guides/FluentBitInstall";
 
-interface AddDataStepSetupProps {
-  selectedTechnology: AddDataTechnologyCatalogEntry | null;
-  signalExpectation: string;
-  selectedSignals: readonly TelemetrySignal[];
-
-  // Configure props
+interface ConfigureProps {
   endpointType: EndpointType;
   onEndpointTypeChange: (type: EndpointType) => void;
   onEndpointTypeManuallySet: () => void;
@@ -50,8 +45,9 @@ interface AddDataStepSetupProps {
   onSelectApmLanguage: (lang: ApmLanguageDefinition) => void;
   fluentBitOutputMode: FluentBitOutputMode;
   onFluentBitOutputModeChange: (mode: FluentBitOutputMode) => void;
+}
 
-  // Install props
+interface InstallProps {
   esUrl: string;
   version: string;
   apiKey: string;
@@ -66,14 +62,23 @@ interface AddDataStepSetupProps {
   derivedOtlpUrl: string | null;
   clusterVersion: string | null;
   connectionUrl: string | null;
+}
 
-  // Verification
+interface VerificationProps {
   connectionAvailable: boolean;
   verification: IngestionVerificationState;
+}
 
-  // Navigation
+interface NavigationProps {
   onBack: () => void;
   onContinue: () => void;
+}
+
+interface AddDataStepSetupProps
+  extends ConfigureProps, InstallProps, VerificationProps, NavigationProps {
+  selectedTechnology: AddDataTechnologyCatalogEntry | null;
+  signalExpectation: string;
+  selectedSignals: readonly TelemetrySignal[];
 }
 
 export default function AddDataStepSetup(p: AddDataStepSetupProps) {

--- a/peek/src/hooks/useRichIngestionVerification.ts
+++ b/peek/src/hooks/useRichIngestionVerification.ts
@@ -76,7 +76,7 @@ export function useRichIngestionVerification(
       if (!connection) throw new Error("No active Elasticsearch connection");
       const client = new ElasticsearchClient(connection);
       const result = await captureFullSnapshot(client, expectedSignalsRef.current, signal);
-      setBaseline(result.snapshot);
+      if (!signal.aborted) setBaseline(result.snapshot);
       return result;
     },
     enabled: Boolean(connection && pollingEnabled && !baseline),

--- a/peek/src/services/addData/ingestionQueries.ts
+++ b/peek/src/services/addData/ingestionQueries.ts
@@ -51,15 +51,21 @@ export interface PerSignalDelta {
 async function queryHostAgentCardinality(
   client: ElasticsearchClient,
   signalType: TelemetrySignal,
+  signal?: AbortSignal,
 ): Promise<{ hostCount: number; agentCount: number }> {
-  const data = await gracefulSearch(client, `${signalType}-*`, {
-    size: 0,
-    query: { range: { "@timestamp": { gte: "now-15m" } } },
-    aggs: {
-      host_count: { cardinality: { field: "host.name", precision_threshold: 3000 } },
-      agent_count: { cardinality: { field: "agent.id", precision_threshold: 3000 } },
+  const data = await gracefulSearch(
+    client,
+    `${signalType}-*`,
+    {
+      size: 0,
+      query: { range: { "@timestamp": { gte: "now-15m" } } },
+      aggs: {
+        host_count: { cardinality: { field: "host.name", precision_threshold: 3000 } },
+        agent_count: { cardinality: { field: "agent.id", precision_threshold: 3000 } },
+      },
     },
-  });
+    signal,
+  );
   if (!data?.aggregations) return { hostCount: 0, agentCount: 0 };
   return {
     hostCount: (data.aggregations.host_count as { value?: number })?.value ?? 0,
@@ -70,12 +76,18 @@ async function queryHostAgentCardinality(
 async function queryDocCount(
   client: ElasticsearchClient,
   signalType: TelemetrySignal,
+  signal?: AbortSignal,
 ): Promise<number> {
-  const data = await gracefulSearch(client, `${signalType}-*`, {
-    size: 0,
-    track_total_hits: true,
-    query: { range: { "@timestamp": { gte: "now-5m" } } },
-  });
+  const data = await gracefulSearch(
+    client,
+    `${signalType}-*`,
+    {
+      size: 0,
+      track_total_hits: true,
+      query: { range: { "@timestamp": { gte: "now-5m" } } },
+    },
+    signal,
+  );
   if (!data?.hits?.total) return 0;
   const total = data.hits.total;
   return typeof total === "number" ? total : (total?.value ?? 0);
@@ -84,11 +96,17 @@ async function queryDocCount(
 async function queryLatestTimestamp(
   client: ElasticsearchClient,
   signalType: TelemetrySignal,
+  signal?: AbortSignal,
 ): Promise<string | null> {
-  const data = await gracefulSearch(client, `${signalType}-*`, {
-    size: 0,
-    aggs: { latest: { max: { field: "@timestamp" } } },
-  });
+  const data = await gracefulSearch(
+    client,
+    `${signalType}-*`,
+    {
+      size: 0,
+      aggs: { latest: { max: { field: "@timestamp" } } },
+    },
+    signal,
+  );
   if (!data?.aggregations) return null;
   return (data.aggregations.latest as { value_as_string?: string })?.value_as_string ?? null;
 }
@@ -101,17 +119,18 @@ export async function captureIngestionSnapshot(
   client: ElasticsearchClient,
   expectedSignals: readonly TelemetrySignal[],
   dataStreamSignals: Set<TelemetrySignal>,
+  signal?: AbortSignal,
 ): Promise<IngestionSnapshot> {
   const signals = await Promise.all(
-    expectedSignals.map(async (signal): Promise<PerSignalSnapshot> => {
+    expectedSignals.map(async (signalType): Promise<PerSignalSnapshot> => {
       const [cardinality, docCount, maxTimestamp] = await Promise.all([
-        queryHostAgentCardinality(client, signal),
-        queryDocCount(client, signal),
-        queryLatestTimestamp(client, signal),
+        queryHostAgentCardinality(client, signalType, signal),
+        queryDocCount(client, signalType, signal),
+        queryLatestTimestamp(client, signalType, signal),
       ]);
       return {
-        signal,
-        dataStreamExists: dataStreamSignals.has(signal),
+        signal: signalType,
+        dataStreamExists: dataStreamSignals.has(signalType),
         hostCount: cardinality.hostCount,
         agentCount: cardinality.agentCount,
         docCount,
@@ -131,7 +150,12 @@ export async function captureFullSnapshot(
   signal?: AbortSignal,
 ): Promise<{ snapshot: IngestionSnapshot; dataStreamSignals: Set<TelemetrySignal> }> {
   const dataStreamSignals = await detectTelemetrySignals(client, signal);
-  const snapshot = await captureIngestionSnapshot(client, expectedSignals, dataStreamSignals);
+  const snapshot = await captureIngestionSnapshot(
+    client,
+    expectedSignals,
+    dataStreamSignals,
+    signal,
+  );
   return { snapshot, dataStreamSignals };
 }
 

--- a/peek/src/services/es/searchHelpers.ts
+++ b/peek/src/services/es/searchHelpers.ts
@@ -48,12 +48,14 @@ export async function gracefulSearch(
   client: ElasticsearchClient,
   index: string,
   body: Record<string, unknown>,
+  signal?: AbortSignal,
 ): Promise<SearchResponse | null> {
   try {
     const response = await client.rawRequest(
       "POST",
       `/${index}/_search?ignore_unavailable=true&allow_no_indices=true`,
       JSON.stringify(body),
+      signal,
     );
     if (response.status >= 400) {
       const error = {


### PR DESCRIPTION
## Summary

Follow-up to #1593 addressing two CodeRabbit review comments that landed before merge but were fixed after the merge commit.

### Changes

**Signal propagation bug fix** (`useRichIngestionVerification.ts`, `ingestionQueries.ts`, `searchHelpers.ts`):

The `AbortSignal` passed to `captureFullSnapshot` was only reaching `detectTelemetrySignals`. The subsequent `captureIngestionSnapshot` → `Promise.all([queryHostAgentCardinality, queryDocCount, queryLatestTimestamp])` calls did not receive or check the signal, meaning `setBaseline` could still execute on an unmounted component if polling was toggled mid-flight.

- `gracefulSearch` now accepts and forwards `signal` to `client.rawRequest`
- `queryHostAgentCardinality`, `queryDocCount`, `queryLatestTimestamp` accept and pass `signal` to `gracefulSearch`
- `captureIngestionSnapshot` accepts `signal` and propagates it to all three query functions
- `captureFullSnapshot` passes `signal` to `captureIngestionSnapshot`
- `baselineQuery.queryFn` guards `setBaseline` with `signal.aborted` check

**Prop grouping** (`AddDataStepSetup.tsx`):

Split the 31-prop `AddDataStepSetupProps` into `ConfigureProps`, `InstallProps`, `VerificationProps`, `NavigationProps` sub-interfaces, with `AddDataStepSetupProps` extending all four.

## Test plan
- [x] All 34 related unit tests pass (`ingestionQueries.test.ts`, `AddDataPage.test.tsx`)
- [x] TypeScript compiles cleanly
- [x] ESLint + Prettier pass