### PR TITLE
fix(ui): service details panel heights and gantt chart header sizing

### DIFF
--- a/peek/src/components/services/ServiceDeploymentsPanel.tsx
+++ b/peek/src/components/services/ServiceDeploymentsPanel.tsx
@@ -27,7 +27,7 @@ interface ServiceDeploymentsPanelProps {
 
 export default function ServiceDeploymentsPanel({ deployments }: ServiceDeploymentsPanelProps) {
   return (
-    <Paper variant="outlined" sx={{ overflow: "auto" }}>
+    <Paper variant="outlined" sx={{ minHeight: 120, overflow: "auto" }}>
       <Box sx={{ p: 1.5, borderBottom: 1, borderColor: "divider" }}>
         <Typography variant="body2" sx={{ fontWeight: 600 }}>
           Deployments

--- a/peek/src/components/services/ServiceRoutesPanel.tsx
+++ b/peek/src/components/services/ServiceRoutesPanel.tsx
@@ -19,7 +19,7 @@ export default function ServiceRoutesPanel({
   onSort,
 }: ServiceRoutesPanelProps) {
   return (
-    <Paper variant="outlined" sx={{ overflow: "auto" }}>
+    <Paper variant="outlined" sx={{ minHeight: 120, overflow: "auto" }}>
       <Box sx={{ p: 1.5, borderBottom: 1, borderColor: "divider" }}>
         <Typography variant="body2" sx={{ fontWeight: 600 }}>
           Top Routes

--- a/peek/src/components/services/ServiceTracesPanel.tsx
+++ b/peek/src/components/services/ServiceTracesPanel.tsx
@@ -24,7 +24,7 @@ export default function ServiceTracesPanel({
   onViewAllTraces,
 }: ServiceTracesPanelProps) {
   return (
-    <Paper variant="outlined" sx={{ overflow: "auto" }}>
+    <Paper variant="outlined" sx={{ minHeight: 120, overflow: "auto" }}>
       <Box
         sx={{
           display: "flex",

--- a/peek/src/components/traces/TraceDetailPanel.tsx
+++ b/peek/src/components/traces/TraceDetailPanel.tsx
@@ -79,7 +79,19 @@ export default function TraceDetailPanel({
         // Without it, the flex-height chain breaks and the span table shows empty.
         <Box sx={{ position: "relative", flex: 1, minHeight: 0 }}>
           <Box
-            sx={{ position: "absolute", top: 0, right: 0, bottom: 0, left: 0, overflow: "hidden" }}
+            sx={{
+              position: "absolute",
+              top: 0,
+              right: 0,
+              bottom: 0,
+              left: 0,
+              overflow: "hidden",
+              // Perses TraceDetails uses MUI h3/h4 variants which default to 3rem/2.125rem,
+              // far too large for a panel header. Scope them down so the gantt table
+              // gets adequate vertical space.
+              "& .MuiTypography-h3": { lineHeight: 1.4, fontSize: "1.25rem" },
+              "& .MuiTypography-h4": { lineHeight: 1.4, fontSize: "0.95rem" },
+            }}
           >
             <VariableContext.Provider value={EMPTY_VARIABLE_SRV}>
               <TracingGanttChart key={selectedTraceId} options={GANTT_OPTIONS} trace={otlpTrace} />


### PR DESCRIPTION
## Summary
- **Service details page**: Deployments, Routes, and Traces panels had `overflow: auto` but no `minHeight`, causing them to visually collapse. Added `minHeight: 120` to each panel's `Paper` wrapper, matching the empty-state pattern already used elsewhere.
- **Trace detail gantt chart**: The Perses `TracingGanttChart` uses MUI `h3` (3rem/48px) and `h4` (2.125rem/34px) Typography variants for the trace details header, consuming most of the panel height and squeezing the actual span table to a tiny area. Scoped the font sizes down (`1.25rem`/`0.95rem`) within the gantt chart wrapper so the span rows get adequate vertical space.

## Test plan
- [ ] Navigate to a service details page (`/services/:name`) and verify Deployments, Routes, and Traces panels render with visible height
- [ ] Open a trace detail panel and verify the gantt chart header (service name + duration) is reasonably sized
- [ ] Verify the span table rows in the gantt chart are visible and scrollable
- [ ] All 2035 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)