### PR TITLE
chore: add Claude Code skills and document custom ESLint rules

### DIFF
--- a/.claude/skills/design-check.md
+++ b/.claude/skills/design-check.md
@@ -1,0 +1,79 @@
+# /design-check — Audit Files Against Design Language
+
+## When to Use
+
+Use `/design-check` to audit component files for violations of the project's design language and custom ESLint rules. Useful before committing, after writing new UI code, or when reviewing a PR.
+
+## What to Check
+
+### Custom ESLint Rules (`eslint-plugin-peek`)
+
+These rules are enforced by the pre-commit hook and CI. Knowing them prevents commit failures:
+
+| Rule | Severity | What It Catches |
+|------|----------|-----------------|
+| `peek/no-hardcoded-colors` | error | Inline hex values in `sx` props — use theme tokens instead |
+| `peek/consistent-typography-variants` | error | Disallowed Typography variants (e.g., `h4`) |
+| `peek/no-direct-echarts-import` | error | Direct `import * as echarts` — use `EChartWrapper` |
+| `peek/no-div-onclick` | error | `<Box onClick>` or `<div onClick>` — use `ButtonBase`, `Button`, `IconButton`, or `ListItemButton` |
+| `peek/enforce-spacing-tokens` | error | MUI spacing values outside the approved set: `0, 0.5, 1, 1.5, 2, 2.5, 3, 4, 6` |
+| `peek/no-hardcoded-heights` | error | Hardcoded pixel heights for standard elements — use `COMPONENT_HEIGHTS` from `src/types/tokens.ts` |
+| `peek/max-component-lines` | warn | Component files over 200 lines — consider decomposing |
+| `peek/enforce-empty-state` | error | Empty-data branches without `<EmptyState>` component |
+| `peek/no-circular-progress` | error | `<CircularProgress>` — use `<ContentSkeleton>` or `<LinearProgress>` |
+| `peek/require-icon-button-aria-label` | error | `<IconButton>` without `aria-label` prop |
+
+### Additional Enforced Rules
+
+| Rule | What It Catches |
+|------|-----------------|
+| `import/order` | Import groups must be separated by blank lines (builtin, external, internal, parent, sibling, index) |
+| `import/no-duplicates` | Duplicate import statements |
+| `no-restricted-imports` | Barrel MUI imports (`@mui/material`) — use path imports (`@mui/material/Button`) |
+| `no-restricted-imports` (components) | Direct `services/es/client` imports in components — use hooks or barrel |
+| `mui/sort-sx-keys` | Unsorted keys in `sx` props (auto-fixable with `eslint --fix`) |
+| `@typescript-eslint/consistent-type-imports` | Missing `import type` for type-only imports |
+
+### DESIGN_LANGUAGE.md Visual Rules
+
+- No drop shadows (`elevation={0}` only)
+- No gradients on surfaces
+- Status indicators use color + icon + text (never color alone)
+- Cards use `border: 1, borderColor: 'divider'` (no shadows)
+- Loading states use `ContentSkeleton` or `LinearProgress` (never `CircularProgress`)
+- Empty states use `<EmptyState>` component with icon, heading, description
+
+### Component Heights (`COMPONENT_HEIGHTS`)
+
+Import from `src/types/tokens.ts`:
+
+```typescript
+import { COMPONENT_HEIGHTS } from "../../types/tokens";
+// button: 36, buttonSmall: 28, input: 36, tableRow: 36,
+// sidebarNavItem: 32, toolbarRow: 44, tab: 36, touchTarget: 44
+```
+
+## Workflow
+
+1. Read the target file(s)
+2. Check each rule from the tables above
+3. Report violations with line numbers and suggested fixes
+4. Optionally run `cd peek && npx eslint --no-error-on-unmatched-pattern <file>` to confirm
+
+## Output Format
+
+```
+## Design Check: <filename>
+
+### Violations
+- **Line 42**: `peek/no-div-onclick` — `<Box onClick>` should be `<ButtonBase onClick>`
+- **Line 57**: `peek/enforce-spacing-tokens` — `mr: 0.75` is not a valid token, use `mr: 1`
+
+### Warnings
+- **peek/max-component-lines** — 215 lines (limit: 200), consider splitting
+
+### Clean
+- No hardcoded colors
+- No hardcoded heights
+- Import order correct
+```

--- a/.claude/skills/file-issue.md
+++ b/.claude/skills/file-issue.md
@@ -1,0 +1,63 @@
+# /file-issue — Research, Design, and File a GitHub Issue
+
+## When to Use
+
+Use `/file-issue` when you want to propose a new feature, enhancement, or bug fix as a structured GitHub issue. This skill follows the project's agentic workflow: issues contain agent-ready implementation plans that AI agents can pick up and execute.
+
+## Workflow
+
+### 1. Research the Codebase
+
+Before designing anything, explore the relevant parts of the codebase:
+
+- Identify existing patterns that the new work should follow
+- Find the specific files, components, hooks, and query builders involved
+- Check for prior art — has something similar been built before?
+- Review `DESIGN_LANGUAGE.md` for visual/interaction constraints
+- Review `DEVELOPING.md` for engineering standards and architecture
+
+### 2. Design the Architecture
+
+Structure the issue body with these sections:
+
+- **Context**: Why this change is needed, what problem it solves
+- **Goals**: Numbered list of concrete deliverables
+- **Proposed Architecture**: Technical design with:
+  - Data sources and field mappings (if applicable)
+  - Page/component structure (following existing archetypes from DESIGN_LANGUAGE.md)
+  - Query builders (following `*QueryBuilder.ts` pattern)
+  - Store slices (if new state is needed)
+  - Route definitions (if new pages)
+  - Cross-linking with existing features
+- **Implementation Phases**: Ordered checklist of work packages
+- **Decisions**: Explicit design decisions and trade-offs
+
+### 3. Ask Clarifying Questions
+
+Before filing, use `AskUserQuestion` to resolve ambiguity on:
+
+- Data sources and index patterns
+- Scope (which entity levels, which signal types)
+- Cross-linking strategy with existing features
+- Any assumptions that affect architecture
+
+### 4. File the Issue
+
+Use `gh issue create` with:
+
+```bash
+gh issue create --title "feat: <concise title>" --body "$(cat <<'EOF'
+<structured issue body>
+EOF
+)"
+```
+
+## Quality Checklist
+
+- [ ] Title is concise and starts with `feat:`, `fix:`, or `chore:`
+- [ ] Context explains the "why" clearly
+- [ ] Architecture names specific files, components, and patterns
+- [ ] Implementation phases are ordered and have checkboxes
+- [ ] Decisions section documents trade-offs explicitly
+- [ ] References existing patterns in the codebase (e.g., "following ServiceInventoryTable pattern")
+- [ ] No speculative features — only what was discussed and agreed upon

--- a/.claude/skills/new-experience.md
+++ b/.claude/skills/new-experience.md
@@ -1,0 +1,98 @@
+# /new-experience — Scaffold a Curated Observability Experience
+
+## When to Use
+
+Use `/new-experience` when building a new "curated experience" — a two-level inventory-to-dashboard view for a specific observability domain (like Services, Kubernetes, Logs, etc.). This skill ensures new experiences follow the established Services pattern.
+
+## Reference Implementation: Services Experience
+
+The Services experience is the canonical pattern. All new experiences should mirror its structure:
+
+```
+peek/src/components/services/
+├── ServiceInventoryPage.tsx          # Top-level page with table + overview cards
+├── ServiceInventoryTable.tsx         # Sortable/searchable inventory table
+├── ServiceOverviewCards.tsx          # Summary stat cards above the table
+├── ServiceInsightsPanel.tsx          # AI-powered insights panel
+├── ServiceDashboardPage.tsx          # Detail dashboard for a single entity
+├── ServiceDashboardControls.tsx      # Dashboard-level filters and time range
+├── ServiceDashboardSummaryCards.tsx  # Summary cards on the dashboard
+├── ServicePerformanceCharts.tsx      # Time-series charts
+├── ServiceRoutesPanel.tsx            # Sub-entity table panel
+├── ServiceTracesPanel.tsx            # Related traces panel
+├── serviceInventoryQueryBuilder.ts   # ES|QL queries for inventory
+├── serviceInventoryHelpers.ts        # Response parsers, formatters, types
+├── serviceDashboardQueryBuilder.ts   # ES|QL queries for dashboard
+├── serviceDashboardHelpers.ts        # Dashboard response parsers
+├── serviceDashboardPageUtils.ts      # Shared dashboard utilities
+├── useServiceInventorySearch.ts      # Inventory data-fetching hook
+└── useServiceDashboardQueries.ts     # Dashboard data-fetching hook
+```
+
+## Scaffold Checklist
+
+### 1. Data Layer
+
+- [ ] **Field mapping type** — `interface <Domain>FieldMapping` with all relevant OTel/ES fields
+- [ ] **Default field mapping** — `DEFAULT_<DOMAIN>_FIELD_MAPPING` constant
+- [ ] **Query builder** — `<domain>InventoryQueryBuilder.ts` with ES|QL query builders
+- [ ] **Helpers** — `<domain>InventoryHelpers.ts` with response parsers and row types
+- [ ] **Dashboard query builder** — `<domain>DashboardQueryBuilder.ts`
+- [ ] **Dashboard helpers** — `<domain>DashboardHelpers.ts`
+
+### 2. State
+
+- [ ] **Store slice** — Add filters to `usePageFiltersStore.ts` or create a dedicated store
+- [ ] **Data-fetching hooks** — `use<Domain>InventorySearch.ts`, `use<Domain>DashboardQueries.ts`
+
+### 3. Inventory Page
+
+- [ ] **Page component** — `<Domain>InventoryPage.tsx` (tabbed if multiple entity levels)
+- [ ] **Overview cards** — `<Domain>OverviewCards.tsx` (total counts, error rates)
+- [ ] **Inventory table** — `<Domain>InventoryTable.tsx` (sortable, searchable, row click drills down)
+- [ ] **Insights panel** — `<Domain>InsightsPanel.tsx` (AI-powered anomaly detection)
+
+### 4. Dashboard Page
+
+- [ ] **Page component** — `<Domain>DashboardPage.tsx`
+- [ ] **Controls** — `<Domain>DashboardControls.tsx` (time range, filters)
+- [ ] **Summary cards** — `<Domain>DashboardSummaryCards.tsx`
+- [ ] **Charts** — Domain-specific time-series panels
+- [ ] **Sub-entity panels** — Tables for related entities
+
+### 5. Integration
+
+- [ ] **Routes** — Add to `manifest.ts` (inventory + dashboard routes)
+- [ ] **Sidebar nav** — Add nav item to sidebar
+- [ ] **Cross-links** — Bidirectional navigation with related experiences
+
+### 6. Testing
+
+- [ ] Unit tests for query builders and helpers
+- [ ] Component tests for inventory page (loading, empty, data states)
+- [ ] Component tests for dashboard page
+- [ ] Accessibility checks via `renderWithA11y`
+
+## Naming Conventions
+
+Follow these patterns (replace `Service` with your domain name):
+
+| Pattern | Example |
+|---------|---------|
+| Page | `ServiceInventoryPage.tsx`, `ServiceDashboardPage.tsx` |
+| Table | `ServiceInventoryTable.tsx` |
+| Cards | `ServiceOverviewCards.tsx`, `ServiceDashboardSummaryCards.tsx` |
+| Query builder | `serviceInventoryQueryBuilder.ts` |
+| Helpers | `serviceInventoryHelpers.ts` |
+| Hook | `useServiceInventorySearch.ts` |
+| Store slice | `use<Domain>FiltersStore.ts` or slice in `usePageFiltersStore.ts` |
+
+## Design Constraints
+
+- Follow `DESIGN_LANGUAGE.md` for all visual patterns
+- Use `COMPONENT_HEIGHTS` from `src/types/tokens.ts` for standard heights
+- Use approved spacing tokens only: `0, 0.5, 1, 1.5, 2, 2.5, 3, 4, 6`
+- Use `ButtonBase` for clickable rows (not `Box onClick`)
+- Use `ContentSkeleton` for loading states, `EmptyState` for empty data
+- Import MUI components from path imports (e.g., `@mui/material/Box`)
+- Separate import groups with blank lines

--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ coverage
 
 __pycache__/
 
-# Claude agent temporary files
-.claude/
+# Claude agent temporary files (but track skills)
+.claude/*
+!.claude/skills/

--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -257,6 +257,40 @@ and adapts. They report only genuine bugs.
 
 Many rules (no `any`, `import type`, import ordering, no duplicate imports) are enforced automatically by ESLint and TypeScript — see `peek/eslint.config.js` and `peek/tsconfig.json`. This section covers the design guidance that requires human judgment.
 
+### Custom ESLint Rules (`eslint-plugin-peek`)
+
+The project has a custom ESLint plugin at `peek/eslint-plugin-peek/` that enforces the design language at lint time. These rules run on every commit via a husky pre-commit hook and in CI. Knowing them prevents commit failures.
+
+**All source files** (`src/**/*.ts`, `src/**/*.tsx`):
+
+| Rule | Severity | What It Enforces |
+|------|----------|------------------|
+| `peek/no-hardcoded-colors` | error | No inline hex values in `sx` props — use theme tokens (`text.secondary`, `background.paper`, etc.) |
+| `peek/consistent-typography-variants` | error | Only approved Typography variants: `h3` (metrics only), `h5`, `h6`, `subtitle1`, `subtitle2`, `body1`, `body2`, `caption`, `overline`. Notably, `h4` is banned. |
+| `peek/no-direct-echarts-import` | error | No `import * as echarts from 'echarts/core'` — use `EChartWrapper` or Perses components |
+| `peek/no-div-onclick` | error | No `<Box onClick>` or `<div onClick>` — use `ButtonBase`, `Button`, `IconButton`, or `ListItemButton` |
+| `peek/enforce-spacing-tokens` | error | MUI spacing values must be in the approved set: `0, 0.5, 1, 1.5, 2, 2.5, 3, 4, 6`. Values like `0.75` or `0.125` are rejected. |
+| `peek/no-hardcoded-heights` | error | No hardcoded pixel heights for standard UI elements — use `COMPONENT_HEIGHTS` from `src/types/tokens.ts` |
+
+**Component files only** (`src/components/**/*.tsx`):
+
+| Rule | Severity | What It Enforces |
+|------|----------|------------------|
+| `peek/max-component-lines` | warn | Component files should not exceed 200 lines — consider decomposing |
+| `peek/enforce-empty-state` | error | Empty-data branches must render the `<EmptyState>` component, not bare placeholders |
+| `peek/no-circular-progress` | error | No `<CircularProgress>` — use `<ContentSkeleton>` or `<LinearProgress>` for loading states |
+| `peek/require-icon-button-aria-label` | error | Every `<IconButton>` must have an `aria-label` prop |
+
+**Other enforced rules** (from third-party plugins):
+
+| Rule | What It Enforces |
+|------|------------------|
+| `import/order` | Import groups separated by blank lines (builtin → external → internal → parent → sibling → index) |
+| `import/no-duplicates` | No duplicate import statements |
+| `no-restricted-imports` | No barrel MUI imports (`@mui/material`) — use path imports (`@mui/material/Button`). Components cannot import directly from `services/es/client`. |
+| `mui/sort-sx-keys` | Sort keys in `sx` props alphabetically (auto-fixable with `eslint --fix`) |
+| `@typescript-eslint/consistent-type-imports` | Use `import type` for type-only imports |
+
 ### TypeScript
 
 - Prefer discriminated unions for state modeling (e.g., `{ status: 'loading' } | { status: 'success'; data: T } | { status: 'error'; error: Error }`) over optional fields.


### PR DESCRIPTION
## Summary

- Add three Claude Code skills in `.claude/skills/` for common workflows:
  - **`/file-issue`** — research codebase, design architecture, file structured GitHub issues following the agentic workflow
  - **`/design-check`** — audit component files against DESIGN_LANGUAGE.md and all custom `eslint-plugin-peek` rules
  - **`/new-experience`** — scaffold curated observability experiences (inventory → dashboard) following the Services pattern
- Document all custom `eslint-plugin-peek` rules in DEVELOPING.md § Custom ESLint Rules so contributors and AI agents know the constraints before writing code
- Update `.gitignore` to track `.claude/skills/` while keeping other `.claude/` contents ignored

## Test plan

- [ ] Verify `.claude/skills/*.md` files render correctly on GitHub
- [ ] Verify DEVELOPING.md custom ESLint rules table matches `peek/eslint.config.js`
- [ ] Confirm `make lint` still passes (no files in `peek/` were changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)