### PR TITLE
fix(slot-insights): address CodeRabbit review feedback

### DIFF
--- a/peek/src/components/InsightSlotContext.tsx
+++ b/peek/src/components/InsightSlotContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useMemo } from "react";
+import React, { createContext, useMemo } from "react";
 
 import type { SlotInsight } from "../types/insightSlots";
 
@@ -15,7 +15,7 @@ interface InsightSlotContextValue {
   refresh: () => void;
 }
 
-const InsightSlotCtx = createContext<InsightSlotContextValue>({
+export const InsightSlotCtx = createContext<InsightSlotContextValue>({
   summary: null,
   insightsBySlot: new Map(),
   loading: false,
@@ -61,21 +61,4 @@ export function InsightSlotProvider({
   );
 
   return React.createElement(InsightSlotCtx.Provider, { value }, children);
-}
-
-/**
- * Returns the insight for a specific slot, or `null` if no insight has been
- * generated for that slot yet.
- */
-export function useSlotInsight(slotId: string): SlotInsight | null {
-  const { insightsBySlot } = useContext(InsightSlotCtx);
-  return insightsBySlot.get(slotId) ?? null;
-}
-
-/**
- * Returns the full context value for advanced consumers that need loading /
- * error / summary information in addition to individual slot insights.
- */
-export function useInsightSlotContext(): InsightSlotContextValue {
-  return useContext(InsightSlotCtx);
 }

--- a/peek/src/components/InsightSlotHooks.ts
+++ b/peek/src/components/InsightSlotHooks.ts
@@ -1,0 +1,22 @@
+import { useContext } from "react";
+
+import type { SlotInsight } from "../types/insightSlots";
+
+import { InsightSlotCtx } from "./InsightSlotContext";
+
+/**
+ * Returns the insight for a specific slot, or `null` if no insight has been
+ * generated for that slot yet.
+ */
+export function useSlotInsight(slotId: string): SlotInsight | null {
+  const { insightsBySlot } = useContext(InsightSlotCtx);
+  return insightsBySlot.get(slotId) ?? null;
+}
+
+/**
+ * Returns the full context value for advanced consumers that need loading /
+ * error / summary information in addition to individual slot insights.
+ */
+export function useInsightSlotContext() {
+  return useContext(InsightSlotCtx);
+}

--- a/peek/src/hooks/insightSlotSchema.ts
+++ b/peek/src/hooks/insightSlotSchema.ts
@@ -5,11 +5,15 @@ import { z } from "zod";
  * page slot insights.  Used with `generateObject` from the AI SDK.
  */
 export const pageInsightsSchema = z.object({
-  summary: z.string().describe("High-level page summary"),
+  summary: z.string().trim().min(1).describe("High-level page summary"),
   insights: z.array(
     z.object({
-      slotId: z.string().describe("Slot identifier matching InsightSlotDefinition.slotId"),
-      text: z.string().describe("Concise insight text for the slot"),
+      slotId: z
+        .string()
+        .trim()
+        .min(1)
+        .describe("Slot identifier matching InsightSlotDefinition.slotId"),
+      text: z.string().trim().min(1).describe("Concise insight text for the slot"),
       severity: z
         .enum(["info", "warning", "critical"])
         .optional()

--- a/peek/src/hooks/usePageSlotInsights.ts
+++ b/peek/src/hooks/usePageSlotInsights.ts
@@ -75,7 +75,10 @@ export function usePageSlotInsights({
         abortSignal: signal,
       });
 
-      return result.object as PageInsightsResponse;
+      // Filter out hallucinated slotIds that weren't in the original request
+      const validSlotIds = new Set(slots.map((s) => s.slotId));
+      const filteredInsights = result.object.insights.filter((i) => validSlotIds.has(i.slotId));
+      return { ...result.object, insights: filteredInsights } as PageInsightsResponse;
     },
     enabled: enabled && hasApiKey && slots.length > 0 && Boolean(context.trim()),
     staleTime: Infinity,

--- a/peek/tests/unit/InsightSlotContext.test.ts
+++ b/peek/tests/unit/InsightSlotContext.test.ts
@@ -4,11 +4,8 @@ import React from "react";
 import { describe, it, expect, vi } from "vitest";
 import { renderHook } from "@testing-library/react";
 
-import {
-  InsightSlotProvider,
-  useSlotInsight,
-  useInsightSlotContext,
-} from "../../src/components/InsightSlotContext";
+import { InsightSlotProvider } from "../../src/components/InsightSlotContext";
+import { useSlotInsight, useInsightSlotContext } from "../../src/components/InsightSlotHooks";
 import type { SlotInsight } from "../../src/types/insightSlots";
 
 const SAMPLE_INSIGHTS: SlotInsight[] = [

--- a/peek/tests/unit/usePageSlotInsights.test.ts
+++ b/peek/tests/unit/usePageSlotInsights.test.ts
@@ -16,7 +16,13 @@ vi.mock("ai", () => ({
 }));
 
 vi.mock("@ai-sdk/openai", () => ({
-  createOpenAI: vi.fn(() => vi.fn(() => ({ id: "test-model" }))),
+  createOpenAI: vi.fn(() => {
+    const client = vi.fn((model: string) => ({ id: model }));
+    (client as typeof client & { chat: (model: string) => { id: string } }).chat = vi.fn(
+      (model: string) => ({ id: model }),
+    );
+    return client;
+  }),
 }));
 
 const SAMPLE_SLOTS: InsightSlotDefinition[] = [
@@ -162,5 +168,66 @@ describe("usePageSlotInsights", () => {
 
     expect(result.current.summary).toBeNull();
     expect(result.current.insights).toEqual([]);
+  });
+
+  it("uses openai.chat() when provider is openrouter", async () => {
+    useLLMStore.getState().setProvider("openrouter");
+    vi.mocked(generateObject).mockResolvedValueOnce({
+      object: {
+        summary: "Router summary.",
+        insights: [{ slotId: "health-card", text: "Via openrouter", severity: "info" }],
+      },
+    });
+
+    const { result } = renderHook(
+      () =>
+        usePageSlotInsights({
+          context: "ctx",
+          systemPrompt: "sys",
+          cacheKey: "openrouter-test",
+          slots: SAMPLE_SLOTS,
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.summary).toBe("Router summary.");
+    });
+
+    expect(vi.mocked(generateObject)).toHaveBeenCalledTimes(1);
+    // Verify the model arg uses the .chat() path (id set by the mock)
+    const callArg = vi.mocked(generateObject).mock.calls[0]![0];
+    expect((callArg.model as { id: string }).id).toMatch(/gpt/);
+  });
+
+  it("filters out hallucinated slotIds not present in the slots input", async () => {
+    vi.mocked(generateObject).mockResolvedValueOnce({
+      object: {
+        summary: "Cluster looks healthy.",
+        insights: [
+          { slotId: "health-card", text: "All nodes green", severity: "info" },
+          { slotId: "hallucinated-slot", text: "This slot was not requested" },
+        ],
+      },
+    });
+
+    const { result } = renderHook(
+      () =>
+        usePageSlotInsights({
+          context: "cluster data",
+          systemPrompt: "sys",
+          cacheKey: "hallucination-test",
+          slots: SAMPLE_SLOTS,
+        }),
+      { wrapper: createWrapper() },
+    );
+
+    await waitFor(() => {
+      expect(result.current.summary).toBe("Cluster looks healthy.");
+    });
+
+    // Only "health-card" is in SAMPLE_SLOTS; "hallucinated-slot" must be filtered
+    expect(result.current.insights).toHaveLength(1);
+    expect(result.current.insights[0]!.slotId).toBe("health-card");
   });
 });


### PR DESCRIPTION
Addresses all 4 CodeRabbit review comments on #1627.

## Changes

### 1. Fast Refresh warning — extract hooks to sibling `.ts` module
- Created `InsightSlotHooks.ts` with `useSlotInsight` and `useInsightSlotContext`
- `InsightSlotContext.tsx` now exports only the `InsightSlotCtx` context object and `InsightSlotProvider` component
- Updated `InsightSlotContext.test.ts` to import hooks from the new file

### 2. Schema hardening — reject empty strings
- Added `.trim().min(1)` to `summary`, `slotId`, and `text` in `pageInsightsSchema`

### 3. Filter hallucinated slotIds
- After receiving the LLM response, `usePageSlotInsights` now filters out any insights whose `slotId` was not present in the original `slots` input

### 4. Test coverage for openrouter path + mock `.chat()`
- Updated `createOpenAI` mock to include a `.chat()` method so the openrouter branch is safe to invoke
- Added test for openrouter provider path (`provider: "openrouter"`)
- Added test for hallucination filtering

All 12 tests pass.