### PR TITLE
fix: break circular chunk dependency causing forwardRef crash on load

### DIFF
--- a/peek/src/components/visualizations/BarChart.tsx
+++ b/peek/src/components/visualizations/BarChart.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useRef, useEffect } from "react";
+import { EChart } from "@perses-dev/components";
 import { formatValue } from "@perses-dev/core";
 import type { ECharts } from "echarts/core";
 
-import { EChart } from "../perses/PersesEChartWrapper";
 import type { EsqlResponse, BarChartOptions } from "../../types";
 import { toBarChartData } from "../../services/perses/dataTransformers";
 import { CHART_COLORS } from "../../theme";

--- a/peek/src/components/visualizations/GaugePanel.tsx
+++ b/peek/src/components/visualizations/GaugePanel.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useRef, useEffect } from "react";
+import { EChart } from "@perses-dev/components";
 import { formatValue } from "@perses-dev/core";
 import type { ECharts } from "echarts/core";
 
-import { EChart } from "../perses/PersesEChartWrapper";
 import type { EsqlResponse, GaugePanelOptions, ThresholdColor, ThresholdStep } from "../../types";
 import { toGaugeData } from "../../services/perses/dataTransformers";
 

--- a/peek/src/components/visualizations/HeatmapChart.tsx
+++ b/peek/src/components/visualizations/HeatmapChart.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useEffect } from "react";
+import { EChart } from "@perses-dev/components";
 import type { ECharts } from "echarts/core";
 
-import { EChart } from "../perses/PersesEChartWrapper";
 import type { EsqlResponse } from "../../types";
 import { HEATMAP_GRADIENT } from "../../types/tokens";
 

--- a/peek/src/components/visualizations/HistogramChart.tsx
+++ b/peek/src/components/visualizations/HistogramChart.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useRef, useEffect } from "react";
+import { EChart } from "@perses-dev/components";
 import { formatValue } from "@perses-dev/core";
 import type { ECharts } from "echarts/core";
 
-import { EChart } from "../perses/PersesEChartWrapper";
 import type { EsqlResponse, HistogramChartOptions } from "../../types";
 import { CHART_COLORS } from "../../theme";
 

--- a/peek/src/components/visualizations/PieChart.tsx
+++ b/peek/src/components/visualizations/PieChart.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useRef, useEffect } from "react";
+import { EChart } from "@perses-dev/components";
 import type { ECharts } from "echarts/core";
 
-import { EChart } from "../perses/PersesEChartWrapper";
 import type { EsqlResponse } from "../../types";
 
 import { useEChartTheme } from "./useEChartTheme";

--- a/peek/src/components/visualizations/ScatterChart.tsx
+++ b/peek/src/components/visualizations/ScatterChart.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useRef, useEffect } from "react";
+import { EChart } from "@perses-dev/components";
 import { formatValue } from "@perses-dev/core";
 import type { ECharts } from "echarts/core";
 
-import { EChart } from "../perses/PersesEChartWrapper";
 import type { EsqlResponse, ScatterChartOptions } from "../../types";
 import { CHART_COLORS } from "../../theme";
 

--- a/peek/src/components/visualizations/TimeSeriesChart.tsx
+++ b/peek/src/components/visualizations/TimeSeriesChart.tsx
@@ -1,8 +1,8 @@
 import { useMemo, useRef, useEffect } from "react";
 import { formatValue } from "@perses-dev/core";
+import { EChart } from "@perses-dev/components";
 import type { ECharts } from "echarts/core";
 
-import { EChart } from "../perses/PersesEChartWrapper";
 import type { EsqlResponse, TimeSeriesOptions } from "../../types";
 import { toTimeSeriesData } from "../../services/perses/dataTransformers";
 import { CHART_COLORS } from "../../theme";


### PR DESCRIPTION
## Summary

The public demo at https://elastic.github.io/ai-github-actions-playground was crashing on load with:
```
TypeError: Cannot read properties of undefined (reading 'forwardRef')
    at codemirror-DHFEBtO6.js:12:63860
```

## Root Cause

Commit #1612 changed all chart components (`BarChart`, `GaugePanel`, etc.) to import `EChart` from `PersesEChartWrapper` (an app-level module) instead of directly from `@perses-dev/components`. This changed Rollup's module resolution order, causing shared helper utilities (`_extends`, CJS interop) to be allocated into the `perses` manual chunk rather than the `mui` chunk.

This created a new `mui → perses` import, turning the previously acyclic chunk dependency graph into a three-way cycle:

```
mui → perses → codemirror → mui
```

When the browser evaluates this cycle at startup, the `codemirror` chunk runs top-level initialization code (`My = ye.forwardRef(...)`) before the `mui` chunk has finished initializing — leaving `ye` (React) as `undefined` → crash.

## Fix

Revert the `EChart` import in the 7 chart components back to `@perses-dev/components` directly. This restores the acyclic chunk structure:
- `mui`: self-contained (no cross-chunk imports)
- `codemirror → mui`
- `perses → mui + codemirror`

The `createPngExporter` improvement from commit #1612 is preserved in all files.

## Verification

Built locally and confirmed:
- No page errors in browser (previously reproduced the crash)
- `mui` chunk has no cross-chunk imports again (matching the known-good state)