### PR TITLE
fix: install Playwright browsers in UX papercuts workflow

### DIFF
--- a/.github/workflows/explore-ux-papercuts.yml
+++ b/.github/workflows/explore-ux-papercuts.yml
@@ -17,6 +17,7 @@ jobs:
       title-prefix: "[ux-papercuts]"
       setup-commands: |
         make serve-explore
+        cd peek && npx playwright install chromium
         cd peek && node scripts/screenshot-section.mjs --section all --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are a **meticulous power user** who works with developer tools


### PR DESCRIPTION
## Summary
- The `explore-ux-papercuts.yml` workflow runs `screenshot-section.mjs` which uses Playwright, but never installs the Chromium browser binary
- `make serve-explore` runs `npm ci` (installs the npm package) but not the actual browser binaries
- Added `cd peek && npx playwright install chromium` to `setup-commands`, matching the pattern used in `give-it-some-love.yml`

## Test plan
- [ ] Verify the workflow YAML is valid
- [ ] Trigger the `UX: Papercuts & Polish` workflow manually and confirm the screenshot step succeeds

Generated with [Claude Code](https://claude.com/claude-code)