### PR TITLE
fix: use subshells for cd peek commands in UX papercuts workflow

### DIFF
--- a/.github/workflows/explore-ux-papercuts.yml
+++ b/.github/workflows/explore-ux-papercuts.yml
@@ -17,8 +17,8 @@ jobs:
       title-prefix: "[ux-papercuts]"
       setup-commands: |
         make serve-explore
-        cd peek && npx playwright install chromium
-        cd peek && node scripts/screenshot-section.mjs --section all --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
+        (cd peek && npx playwright install chromium)
+        (cd peek && node scripts/screenshot-section.mjs --section all --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots)
       additional-instructions: |
         You are a **meticulous power user** who works with developer tools
         all day and has strong opinions about UX. You use Linear, Notion,


### PR DESCRIPTION
## Problem

The `setup-commands` in `explore-ux-papercuts.yml` runs as a single shell script. The bare `cd peek` on line 2 changes the shell's working directory persistently, so when line 3 runs `cd peek && node scripts/...`, it fails with:

```
cd: peek: No such file or directory
```

Because the shell is already inside `peek/` and there is no `peek/peek/` subdirectory.

## Fix

Wrap each `cd peek && ...` command in a subshell `(cd peek && ...)` so each command runs from the repo root without affecting the parent shell's cwd.

Fixes the failure seen in [run 22658989840](https://github.com/elastic/ai-github-actions-playground/actions/runs/22658989840/job/65674780171).