### PR TITLE
fix(workflows): add playwright install to all explore section workflows

### DIFF
--- a/.github/workflows/explore-add-data.yml
+++ b/.github/workflows/explore-add-data.yml
@@ -18,6 +18,7 @@ jobs:
       title-prefix: "[explore-add-data]"
       setup-commands: |
         make serve-explore
+        (cd peek && npx playwright install chromium)
         cd peek && node scripts/screenshot-section.mjs --section add-data --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are the **Add Data Wizard Explorer** — a creative QA tester who

--- a/.github/workflows/explore-cluster-overview.yml
+++ b/.github/workflows/explore-cluster-overview.yml
@@ -18,6 +18,7 @@ jobs:
       title-prefix: "[explore-cluster-overview]"
       setup-commands: |
         make serve-explore
+        (cd peek && npx playwright install chromium)
         cd peek && node scripts/screenshot-section.mjs --section cluster-overview --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are the **Cluster Overview Explorer** — a creative QA tester who

--- a/.github/workflows/explore-dashboards.yml
+++ b/.github/workflows/explore-dashboards.yml
@@ -18,6 +18,7 @@ jobs:
       title-prefix: "[explore-dashboards]"
       setup-commands: |
         make serve-explore
+        (cd peek && npx playwright install chromium)
         cd peek && node scripts/screenshot-section.mjs --section dashboards --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are the **Dashboards Explorer** — a creative QA tester who owns

--- a/.github/workflows/explore-data-management.yml
+++ b/.github/workflows/explore-data-management.yml
@@ -18,6 +18,7 @@ jobs:
       title-prefix: "[explore-data-management]"
       setup-commands: |
         make serve-explore
+        (cd peek && npx playwright install chromium)
         cd peek && node scripts/screenshot-section.mjs --section data-management --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are the **Data Management Explorer** — a creative QA tester

--- a/.github/workflows/explore-fleet-add-data.yml
+++ b/.github/workflows/explore-fleet-add-data.yml
@@ -18,6 +18,7 @@ jobs:
       title-prefix: "[explore-fleet]"
       setup-commands: |
         make serve-explore
+        (cd peek && npx playwright install chromium)
         cd peek && node scripts/screenshot-section.mjs --section fleet --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are the **Fleet Explorer** — a creative QA tester who owns the

--- a/.github/workflows/explore-logs.yml
+++ b/.github/workflows/explore-logs.yml
@@ -18,6 +18,7 @@ jobs:
       title-prefix: "[explore-logs]"
       setup-commands: |
         make serve-explore
+        (cd peek && npx playwright install chromium)
         cd peek && node scripts/screenshot-section.mjs --section logs --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are the **Logs Explorer** — a creative QA tester who owns the

--- a/.github/workflows/explore-metrics.yml
+++ b/.github/workflows/explore-metrics.yml
@@ -18,6 +18,7 @@ jobs:
       title-prefix: "[explore-metrics]"
       setup-commands: |
         make serve-explore
+        (cd peek && npx playwright install chromium)
         cd peek && node scripts/screenshot-section.mjs --section metrics --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are the **Metrics & Charts Explorer** — a creative QA tester

--- a/.github/workflows/explore-profiling.yml
+++ b/.github/workflows/explore-profiling.yml
@@ -18,6 +18,7 @@ jobs:
       title-prefix: "[explore-profiling]"
       setup-commands: |
         make serve-explore
+        (cd peek && npx playwright install chromium)
         cd peek && node scripts/screenshot-section.mjs --section profiling --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are the **Profiling Explorer** — a UI/UX tester for the Profiling

--- a/.github/workflows/explore-query-lab.yml
+++ b/.github/workflows/explore-query-lab.yml
@@ -18,6 +18,7 @@ jobs:
       title-prefix: "[explore-query-lab]"
       setup-commands: |
         make serve-explore
+        (cd peek && npx playwright install chromium)
         cd peek && node scripts/screenshot-section.mjs --section query-lab --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are the **Query Lab & Console Explorer** — a creative QA

--- a/.github/workflows/explore-security.yml
+++ b/.github/workflows/explore-security.yml
@@ -18,6 +18,7 @@ jobs:
       title-prefix: "[explore-security]"
       setup-commands: |
         make serve-explore
+        (cd peek && npx playwright install chromium)
         cd peek && node scripts/screenshot-section.mjs --section security --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are the **Security Explorer** — a creative QA tester who owns

--- a/.github/workflows/explore-services.yml
+++ b/.github/workflows/explore-services.yml
@@ -18,6 +18,7 @@ jobs:
       title-prefix: "[explore-services]"
       setup-commands: |
         make serve-explore
+        (cd peek && npx playwright install chromium)
         cd peek && node scripts/screenshot-section.mjs --section services --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are the **Services Explorer** — a creative QA tester who owns the

--- a/.github/workflows/explore-traces.yml
+++ b/.github/workflows/explore-traces.yml
@@ -18,6 +18,7 @@ jobs:
       title-prefix: "[explore-traces]"
       setup-commands: |
         make serve-explore
+        (cd peek && npx playwright install chromium)
         cd peek && node scripts/screenshot-section.mjs --section traces --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
       additional-instructions: |
         You are the **Traces & Service Map Explorer** — a creative QA


### PR DESCRIPTION
## Problem

12 of the 13 explore workflows call `screenshot-section.mjs` (which uses Playwright internally) without first installing the Chromium browser binary. This causes the screenshot step to fail with:

```
browserType.launch: Executable doesn't exist at .../chromium-*/chrome-linux/chrome
```

`explore-ux-papercuts` already had `(cd peek && npx playwright install chromium)` before the screenshot step — the other 12 were missing it.

## Fix

Added `(cd peek && npx playwright install chromium)` to `setup-commands` in all 12 affected workflows, immediately before the `screenshot-section.mjs` call (same position/pattern as `explore-ux-papercuts`).

**Affected workflows:** explore-add-data, explore-cluster-overview, explore-dashboards, explore-data-management, explore-fleet-add-data, explore-logs, explore-metrics, explore-profiling, explore-query-lab, explore-security, explore-services, explore-traces.