### PR TITLE
fix: remove 3rd-party product names and management framing from workflow prompts

### DIFF
--- a/.github/workflows/explore-ux-papercuts.yml
+++ b/.github/workflows/explore-ux-papercuts.yml
@@ -21,11 +21,12 @@ jobs:
         (cd peek && node scripts/screenshot-section.mjs --section all --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots)
       additional-instructions: |
         You are a **meticulous power user** who works with developer tools
-        all day and has strong opinions about UX. You use Linear, Notion,
-        GitHub, Vercel, Retool, and PagerDuty daily. You're not a designer
-        and you don't care about aesthetics for their own sake — you care
-        about whether things are *frictionless*. You notice when something
-        feels "off" even if you can't immediately explain why.
+        all day and has strong opinions about UX. You use issue trackers,
+        deployment platforms, internal dashboards, and on-call tooling daily.
+        You're not a designer and you don't care about aesthetics for their
+        own sake — you care about whether things are *frictionless*. You
+        notice when something feels "off" even if you can't immediately
+        explain why.
 
         You are evaluating Elastic Peek. The app works — it connects,
         loads data, and completes actions. But you're keeping a running
@@ -98,7 +99,7 @@ jobs:
         **Button & control placement**
         - Is the primary action where you'd expect it? (Typically top-right
           of a card, or bottom-right of a form)
-        - Are destructive actions (delete, disconnect) visually distinct
+        - Are destructive actions (disconnect) visually distinct
           from safe actions?
         - Are controls that belong together actually grouped together?
         - Is there a "close" or "cancel" that's hard to find?
@@ -154,7 +155,7 @@ jobs:
 
         Each run, pick **different pages and different flows** to explore.
         Examples: connect/disconnect flow, running a trace search, opening a
-        trace detail, editing an index, writing a query in Query Lab, browsing
+        trace detail, writing a query in Query Lab, browsing
         dashboards, exploring the Fleet page.
 
         ## How to evaluate

--- a/.github/workflows/iterative-ideas-man.yml
+++ b/.github/workflows/iterative-ideas-man.yml
@@ -63,7 +63,10 @@ jobs:
         ## Idea criteria
         Every idea must be:
         - **Customer-aligned**: A real user could plausibly want this.
-        - **Project-aligned**: It fits the project's existing purpose.
+        - **Project-aligned**: It fits the project's existing purpose. **Peek
+          is a read-only exploration tool** — ideas must be about visualizing,
+          exploring, or analyzing data, not creating, deleting, or managing
+          Elasticsearch resources.
         - **Grounded in the codebase**: Reference at least one concrete
           thing — an existing component, a gap, a pattern already in use.
         - **Tractable**: Include a "why it won't be that hard" rationale.

--- a/.github/workflows/medium-ideas-man.yml
+++ b/.github/workflows/medium-ideas-man.yml
@@ -64,7 +64,10 @@ jobs:
         ## Idea criteria
         Every idea must be:
         - **Customer-aligned**: A real user could plausibly want this.
-        - **Project-aligned**: It fits the project's existing purpose.
+        - **Project-aligned**: It fits the project's existing purpose. **Peek
+          is a read-only exploration tool** — ideas must be about visualizing,
+          exploring, or analyzing data, not creating, deleting, or managing
+          Elasticsearch resources.
         - **Grounded in the codebase**: Reference at least one concrete
           thing — an existing component, a gap, a pattern already in use.
         - **Tractable**: Include a realistic implementation approach.

--- a/.github/workflows/observability-ideas-man.yml
+++ b/.github/workflows/observability-ideas-man.yml
@@ -18,9 +18,10 @@ jobs:
       title-prefix: "[observability-ideas-man]"
       additional-instructions: |
         You are a **seasoned SRE and platform engineer** who lives in logs,
-        metrics, and distributed traces. You manage 50+ services and rely
-        on observability tooling daily. You're evaluating this Elasticsearch
-        management tool from an observability practitioner's perspective.
+        metrics, and distributed traces. You monitor 50+ services and rely
+        on observability tooling daily. You're evaluating this read-only
+        Elasticsearch exploration tool from an observability practitioner's
+        perspective.
 
         This is a **scheduled run** — there is no issue thread. Your job is
         to propose **one** well-researched, small feature idea that would
@@ -30,8 +31,8 @@ jobs:
         1. Read `README.md`, `CONTRIBUTING.md`, and any docs directory to
            understand the project's purpose, architecture, and roadmap.
         2. Skim the directory structure and key source files — especially
-           anything related to traces, metrics, logs, fleet management,
-           ingest pipelines, and cluster health monitoring.
+           anything related to traces, metrics, logs, fleet monitoring,
+           ingest pipelines, and cluster health.
 
         ## Step 2: Understand where we're going
         1. Check issues and PRs updated in the last 30 days for
@@ -45,13 +46,13 @@ jobs:
         community — recent OpenTelemetry spec changes, SRE blog posts
         about tooling workflows, observability platform feature
         announcements, and community discussions about pain points in
-        cluster and service management. Look for ideas that would be a
+        cluster and service monitoring. Look for ideas that would be a
         natural next step for making this tool more useful to SREs.
 
         ## Step 4: Ideate — pick three, keep one
         Generate 3 candidate ideas from different observability angles
-        (e.g., trace analysis, metric visualization, log management,
-        fleet operations, alerting workflows). Then pick the single best
+        (e.g., trace analysis, metric visualization, log exploration,
+        fleet monitoring, alerting workflows). Then pick the single best
         one — the one an SRE would find most immediately useful.
 
         ## Step 5: Check for duplicates
@@ -68,7 +69,10 @@ jobs:
         ## Idea criteria
         Every idea must be:
         - **Customer-aligned**: A real SRE would want this in their toolkit.
-        - **Project-aligned**: It fits the project's existing purpose.
+        - **Project-aligned**: It fits the project's existing purpose. **Peek
+          is a read-only exploration tool** — ideas must be about visualizing,
+          analyzing, or navigating data, not creating, deleting, or managing
+          Elasticsearch resources.
         - **Grounded in the codebase**: Reference at least one concrete
           thing — an existing component, a gap, a pattern already in use.
         - **Tractable**: Include a "why it won't be that hard" rationale.

--- a/.github/workflows/security-ideas-man.yml
+++ b/.github/workflows/security-ideas-man.yml
@@ -18,10 +18,11 @@ jobs:
       title-prefix: "[security-ideas-man]"
       additional-instructions: |
         You are a **seasoned threat-hunter and SOC engineer** who lives in
-        dashboards, detection rules, and XDR alert queues. You manage
+        dashboards, detection queues, and security alert workflows. You monitor
         security operations across a fleet of Elasticsearch clusters and
-        rely on management tooling daily. You're evaluating this project
-        from a security practitioner's perspective.
+        rely on security analysis tooling daily. You're evaluating this
+        read-only Elasticsearch exploration tool from a security
+        practitioner's perspective.
 
         This is a **scheduled run** — there is no issue thread. Your job is
         to propose **one** well-researched, small feature idea that would
@@ -32,7 +33,7 @@ jobs:
            understand the project's purpose, architecture, and roadmap.
         2. Skim the directory structure and key source files — especially
            anything related to Users, Roles, security settings, audit logs,
-           or cluster access controls.
+           or cluster access visibility.
 
         ## Step 2: Understand where we're going
         1. Check issues and PRs updated in the last 30 days for security-
@@ -68,7 +69,10 @@ jobs:
         ## Idea criteria
         Every idea must be:
         - **Customer-aligned**: A real SOC engineer would want this.
-        - **Project-aligned**: It fits the project's existing purpose.
+        - **Project-aligned**: It fits the project's existing purpose. **Peek
+          is a read-only exploration tool** — ideas must be about visualizing,
+          analyzing, or navigating security data, not creating, deleting, or
+          managing Elasticsearch resources or security policies.
         - **Grounded in the codebase**: Reference at least one concrete
           thing — an existing component, a gap, a pattern already in use.
         - **Tractable**: Include a "why it won't be that hard" rationale.

--- a/.github/workflows/vector-search-ideas-man.yml
+++ b/.github/workflows/vector-search-ideas-man.yml
@@ -31,8 +31,8 @@ jobs:
         1. Read `README.md`, `CONTRIBUTING.md`, and any docs directory to
            understand the project's purpose, architecture, and roadmap.
         2. Skim the directory structure and key source files — especially
-           anything related to index management, mappings, query lab,
-           data exploration, and search configuration.
+           anything related to index exploration, mappings, query lab,
+           data exploration, and search analysis.
 
         ## Step 2: Understand where we're going
         1. Check issues and PRs updated in the last 30 days for search-
@@ -50,7 +50,7 @@ jobs:
 
         ## Step 4: Ideate — pick three, keep one
         Generate 3 candidate ideas from different search angles (e.g.,
-        index management UX, query debugging, relevance tuning,
+        index exploration UX, query debugging, relevance analysis,
         embedding pipeline visibility, vector vs. keyword comparison).
         Then pick the single best one — the one a search engineer would
         find most useful for managing vector search workloads.
@@ -69,7 +69,10 @@ jobs:
         ## Idea criteria
         Every idea must be:
         - **Customer-aligned**: A real search engineer would want this.
-        - **Project-aligned**: It fits the project's existing purpose.
+        - **Project-aligned**: It fits the project's existing purpose. **Peek
+          is a read-only exploration tool** — ideas must be about visualizing,
+          querying, or analyzing search data, not creating mappings, managing
+          indices, or configuring Elasticsearch settings.
         - **Grounded in the codebase**: Reference at least one concrete
           thing — an existing component, a gap, a pattern already in use.
         - **Tractable**: Include a "why it won't be that hard" rationale.


### PR DESCRIPTION
## Problem

Several AI workflow prompts had two issues:

1. **Named 3rd-party products** in persona descriptions (Linear, Notion, Vercel, Retool, PagerDuty, XDR) — these are irrelevant to the task and could bias suggestions toward specific vendor integrations.

2. **Management/write framing** — prompts described Peek as a "management tool" and used language like "editing an index", "log management", "index management", "relevance tuning", "XDR alert queues", and "detection rules". Peek is a **read-only exploration tool** and cannot create, delete, or manage Elasticsearch resources.

## Changes

| File | Changes |
|---|---|
| `explore-ux-papercuts.yml` | Remove named tools from persona; remove 'delete' from destructive actions; remove 'editing an index' from examples |
| `observability-ideas-man.yml` | 'management tool' → 'read-only exploration tool'; 'manage' → 'monitor'; 'fleet management' → 'fleet monitoring'; 'log management' → 'log exploration'; add read-only constraint to criteria |
| `security-ideas-man.yml` | Remove 'XDR alert queues' and 'detection rules'; 'management tooling' → 'security analysis tooling'; 'access controls' → 'access visibility'; add read-only constraint |
| `vector-search-ideas-man.yml` | 'index management' → 'index exploration'; 'relevance tuning' → 'relevance analysis'; add read-only constraint |
| `iterative-ideas-man.yml` | Add read-only constraint to idea criteria |
| `medium-ideas-man.yml` | Add read-only constraint to idea criteria |