### PR TITLE
fix: soften literal UI strings in explore prompts and add Prompt Suggestions

### DIFF
--- a/.github/workflows/explore-add-data.yml
+++ b/.github/workflows/explore-add-data.yml
@@ -36,20 +36,22 @@ jobs:
 
         The wizard is a **3-step flow**:
 
-        1. **What are you monitoring?** — Experience tile selection → technology
-           selection
-        2. **Set up and verify** — Collapsible accordion sections for
+        1. **Technology selection** — Choose what you're monitoring via
+           experience tiles and technology cards
+        2. **Setup & verification** — Collapsible accordion sections for
            environment configuration, install commands, credentials, and
            ingestion verification
-        3. **Explore your data + next steps** — Success CTAs
+        3. **Success / next steps** — CTAs to explore data or add more sources
 
-        There is **no step progress bar**. Navigation between steps uses
-        "Continue" and "Back" buttons at the bottom of each step.
+        Navigation between steps uses Continue and Back buttons at the
+        bottom of each step. The cluster version is pre-filled into
+        install commands.
 
-        The page header shows "Add Data" with the subtitle "Set up a new
-        telemetry source". There is no EDOT Collector version chip in the
-        header — the cluster version is pre-filled into install commands
-        instead.
+        **Important**: The step titles, subtitles, and descriptions in
+        this prompt are approximate — they describe the *purpose* of each
+        section so you can navigate. Do NOT compare exact wording against
+        the UI. If a title says something slightly different but serves
+        the same purpose, that is fine.
 
         ## Technologies
 
@@ -88,67 +90,48 @@ jobs:
 
         ---
 
-        ## Step 1: What are you monitoring?
+        ## Step 1: Technology selection
 
-        Navigate to Add Data. You should see:
-        - A page header with "Add Data" title and "Set up a new telemetry
-          source" subtitle (no version chip, no step progress bar)
-        - A section titled "What are you monitoring?" with a subtitle:
-          "Pick a technology to tailor environment choices, setup commands,
-          and verification checks."
-        - A search box ("Search integrations...")
-        - Four large **experience tiles** in a 2×2 grid:
-          "Cloud Providers", "Kubernetes", "Servers, Desktops & Laptops",
-          "SaaS & Databases"
-        - An **Advanced** collapsible accordion below the tiles
-        - A "Continue" button (disabled until a technology is selected)
+        Navigate to Add Data. The first step lets you pick a technology.
+        You should see experience tiles (categories like Cloud, Kubernetes,
+        Servers, SaaS/Databases), a search box, and an Advanced accordion
+        that reveals APM languages and Fluent Bit.
 
         Interactions to try on any given run:
 
         - **Search filtering**: Type a partial technology name (e.g., "dock",
-          "linux", "post", "ngin") into the search box. The experience tiles
-          should disappear and a filtered list of technology cards should
-          appear. Clear the search — the tiles should return.
-        - **Experience tile navigation**: Click an experience tile (e.g.,
-          "SaaS & Databases"). The tiles disappear, replaced by the
-          technologies in that experience. A back button with the experience
-          name appears at the top left. Click it to return to the tiles.
-        - **Advanced accordion**: Click the "Advanced" section to expand it.
-          APM languages (Java, Python, Node.js, etc.) and Fluent Bit should
-          appear. Collapse it again.
-        - **Selecting a technology**: Click a technology card. It should
-          become visually selected. Selecting a different technology should
-          deselect the previous one.
-        - **Continue button disabled**: Without selecting anything, the
-          "Continue" button should be disabled. Select a tech and verify it
-          becomes enabled.
+          "linux", "post", "ngin") into the search box. The tiles should
+          filter to matching results. Clear the search — the original
+          layout should return.
+        - **Experience tile navigation**: Click an experience tile. It should
+          drill into that category's technologies. A back link should let
+          you return to the tile view.
+        - **Advanced accordion**: Expand it to reveal APM languages and
+          Fluent Bit. Collapse it again.
+        - **Selection**: Click a technology card — it should become visually
+          selected. Selecting a different one should deselect the previous.
+        - **Continue gating**: The Continue button should be disabled until
+          a technology is selected.
 
-        Pick a technology and click "Continue".
+        Pick a technology and click Continue.
 
         ---
 
-        ## Step 2: Set up and verify
+        ## Step 2: Setup & verification
 
         This is the richest step. It consolidates environment selection,
         install commands, credentials, and ingestion verification into a
         single page with collapsible accordion sections.
 
-        You should see:
-        - A title "Set up and verify"
+        The page should show:
         - A description mentioning the expected signals for the chosen
-          technology (e.g., "Kubernetes can emit metrics, logs and traces.")
-        - **Collapsible section 1** — guide-specific configuration
-          (label varies by guide type, e.g., "Select your environment" for
-          EDOT Collector, "Configure receiver" for OTel Receiver, "Select
-          language" for APM, "Select AWS services" for AWS, "Configure
-          output" for Fluent Bit)
-        - **Collapsible section 2** — install commands + collector credentials
-          (label varies, e.g., "Install and configure" for EDOT Collector,
-          "Instrument your app" for APM, "Deploy stack" for AWS, "Install
-          Fluent Bit" for Fluent Bit)
-        - **Verification panel** — inline "Check now" verification (not
-          collapsible)
-        - "Back" and "Continue" buttons
+          technology (e.g., metrics, logs, traces)
+        - **Collapsible section 1** — guide-specific environment or
+          receiver configuration (the label varies by guide type)
+        - **Collapsible section 2** — install commands and credentials
+          (the label varies by guide type)
+        - **Verification panel** — a way to check whether data is arriving
+        - Back and Continue buttons
 
         ### Section 1: Environment configuration (EDOT Collector guide type)
 
@@ -158,9 +141,9 @@ jobs:
 
         Interactions to try:
 
-        - **Endpoint type toggle**: Click "Managed OTLP". An alert should
-          show the OTLP endpoint probe status. Switch back to
-          "Elasticsearch". The alert should disappear.
+        - **Endpoint type toggle**: Switch between Elasticsearch and
+          Managed OTLP. The UI should update to reflect the chosen
+          endpoint — look for relevant status indicators or alerts.
         - **Platform tab switching**: Click through the platform tabs. The
           active tab should be visually distinct.
 
@@ -191,76 +174,57 @@ jobs:
         - The **cluster version** should be pre-filled in the commands.
 
         **Copy button interactions**:
-        - Click "Copy all" — the button text should briefly change to
-          "Copied!" then revert.
-        - Click per-step "Copy" buttons — each should show "Copied!" feedback
-          independently.
+        - Click copy buttons (both per-step and copy-all if present).
+          Each should give visual feedback confirming the copy.
 
         **API key generation** (capabilities-gated):
         - If the connected user **has** API key creation privileges:
-          A "Generate API key" button appears. Click it — a loading spinner
-          should appear briefly, then a Base64 API key value should appear in
-          a read-only text field. A warning alert should appear: "Copy this
-          API key now. You will not be able to read it again after leaving
-          this page." The copy button should work. The `<YOUR_API_KEY>`
-          placeholder in the command should be replaced with the actual key.
-        - If the connected user **does not** have API key creation privileges:
-          A warning alert appears: "Your credentials do not include API key
-          creation privileges. Generate a key manually via Create API key
-          endpoint or ask an administrator to provision one for collector
-          onboarding." This is expected — do NOT report it as a bug.
+          Look for a generate-key button. Click it — a key value should
+          appear. There should be a warning that the key is only shown
+          once. The API key placeholder in the commands should be replaced
+          with the actual key.
+        - If the connected user **does not** have API key creation
+          privileges: An alert explains how to create a key manually.
+          This is expected — do NOT report it as a bug.
 
         ### Verification panel
 
-        Below the collapsible sections, the verification panel shows:
-        - A description: "For {technology}, we expect to receive
-          {signalExpectation}."
-        - A "Check now" button with a checkmark icon
+        Below the collapsible sections, a verification panel lets you
+        check whether data is arriving from the collector.
 
         Interactions to try:
 
-        - **Click "Check now"**: The button should show a spinner and change
-          to "Checking...". A pulsing info icon and "Listening for data..."
-          text should appear. Since the collector is not actually running, an
-          info alert should appear: "No new data detected yet. Make sure the
-          collector is running — we'll keep checking automatically." with a
-          troubleshooting docs link.
-        - **Auto-polling**: If you generated an API key, polling may have
-          started automatically. The "Listening for data..." indicator should
-          appear without clicking "Check now".
-        - **"Check now" disabled while capturing baseline**: During baseline
-          capture, the button is disabled.
-        - **Troubleshooting link**: The "no data" alert should contain a link
-          to elastic.co observability docs. Verify it exists.
+        - **Trigger a check**: Click the verification button. It should
+          show a loading/polling state. Since no collector is actually
+          running, the UI should eventually show a "no data yet" message
+          with guidance or a troubleshooting link.
+        - **Auto-polling**: If you generated an API key, polling may start
+          automatically.
+        - **Button disable state**: The check button may be temporarily
+          disabled while capturing a baseline.
 
-        Click "Continue" to proceed to the success step.
+        Click Continue to proceed to the success step.
 
         ---
 
-        ## Step 3: Explore your data + next steps
+        ## Step 3: Success / next steps
 
-        You should see:
-        - A title "Explore your data + next steps"
-        - A description: "{technology} is configured. Choose a next action to
-          explore dashboards, set up alerting, or onboard another source."
-        - A green "Ready signals" alert if signals were found (or expected
-          signals if none were found)
-        - A row of CTA buttons. Signal-specific CTAs (e.g., "Open traces",
-          "Explore metrics", "Open Query Lab") use contained/primary style.
-          Utility CTAs ("Open Dashboards", "Set up alerting", "Add another
-          source") use outlined style.
-        - A "Back" button
+        The final step confirms setup and offers next actions. You should
+        see CTA buttons relevant to the signals the technology produces
+        (e.g., links to traces, metrics, logs, dashboards) plus utility
+        actions like adding another source. There should also be a Back
+        button.
 
         Interactions to try:
 
-        - **CTA buttons presence**: Count the CTA buttons. A technology that
-          emits metrics + logs + traces should have signal CTAs for each.
-        - **"Add another source"**: Click this button. It should reset the
-          wizard back to Step 1 with experience tiles visible and no
-          technology selected.
-        - **Navigate via signal CTAs**: Click "Open traces" (if available).
-          Does it navigate to the Traces page? Use the browser Back button
-          to return. Try "Open Dashboards" — does it navigate to Dashboards?
+        - **CTA relevance**: Do the offered CTAs match the signals the
+          chosen technology emits? A tech that produces traces should
+          have a trace-related CTA.
+        - **Add another source**: Look for a way to restart the wizard.
+          Clicking it should reset back to the technology selection step
+          with nothing pre-selected.
+        - **Navigation**: Click a signal CTA — does it navigate to the
+          expected page? Use the browser Back button to return.
 
         ---
 
@@ -366,8 +330,7 @@ jobs:
            summary text?
 
         3. **Collapsible section headers**: In Step 2, verify the accordion
-           section headers ("Select your environment", "Install and
-           configure", etc.) are clearly labeled and the expand/collapse
+           section headers are clearly labeled and the expand/collapse
            icons are visible.
 
         4. **Code block readability in dark mode**: Switch to dark mode
@@ -401,5 +364,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-cluster-overview.yml
+++ b/.github/workflows/explore-cluster-overview.yml
@@ -51,19 +51,16 @@ jobs:
         This is the main summary dashboard. It shows info cards and an embedded
         nodes table.
 
-        - Count and read the info cards: cluster name, node count, version,
-          health status, data stream count, index count, aliases count, docs
-          count, store size, total shards, total indices, node role summary.
-          Are values plausible?
-        - The **Health card** is clickable — does it navigate to
-          `/cluster-health`? Does the cluster-health page show detail?
-        - The **Data Streams card** is clickable — does it navigate to
-          `/data-streams`?
-        - The **Indices card** is clickable — does it navigate to `/indices`?
-        - The **Nodes table** at the bottom shows each node with its name and
-          status. Are node role badges visible?
-        - If a **Fleet summary** card is present (showing total/healthy/offline
-          agents), is it readable? Does "View Fleet →" link navigate correctly?
+        - Count and read the info cards (they may include cluster name,
+          node count, version, health, data streams, indices, docs, store
+          size, shards, etc.). Are values plausible?
+        - Check if any info cards are clickable — do they navigate to
+          relevant detail pages (e.g., cluster health, data streams,
+          indices)?
+        - Look for a nodes table showing node names and status. Are node
+          role indicators visible?
+        - If a Fleet summary card is present, is it readable? Does its
+          link navigate correctly?
         - Navigate away to Indices, then back to Cluster Overview. Does data
           refresh?
         - Resize the browser to a narrow width (800px). Do the info cards wrap
@@ -76,8 +73,8 @@ jobs:
         Navigate to `http://localhost:3000/ai-github-actions-playground/cluster-health`
         or click the "Health" entry in the sidebar.
 
-        - Does the page show cluster status (green/yellow/red), shard counts,
-          active shards, unassigned shards?
+        - Does the page show cluster health status, shard counts, and
+          related cluster health metrics?
         - Are the numeric values formatted readably?
         - Is there an AI Insight banner? Is the content relevant and readable?
 
@@ -226,5 +223,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-connection.yml
+++ b/.github/workflows/explore-connection.yml
@@ -91,5 +91,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-customer-feedback.yml
+++ b/.github/workflows/explore-customer-feedback.yml
@@ -114,5 +114,10 @@ jobs:
           gaps are both fair game.
         - If you genuinely can't find any gaps (unlikely), do not open
           an issue.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a gap. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-dashboards.yml
+++ b/.github/workflows/explore-dashboards.yml
@@ -142,5 +142,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-data-management.yml
+++ b/.github/workflows/explore-data-management.yml
@@ -144,5 +144,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-fleet-add-data.yml
+++ b/.github/workflows/explore-fleet-add-data.yml
@@ -28,8 +28,8 @@ jobs:
         follow a fixed script. Examples of things you might try on any given
         run:
 
-        - Navigate to Fleet. How many agents are listed? Do they show status
-          (online/offline/updating), version, and policy?
+        - Navigate to Fleet. How many agents are listed? Do they show
+          agent status, version, and assigned policy?
         - Click an agent row. Does a detail view open showing agent metadata?
         - Check if the table has a search input. Try searching for an agent
           by name. Try searching for something that doesn't exist.
@@ -98,8 +98,8 @@ jobs:
 
         1. **Fleet table empty state**: If no agents are enrolled, is the
            empty state polished — icon, title, and a hint about how to enroll?
-        2. **Agent status badges**: Do Online/Offline/Updating badges use
-           distinct and readable colors in both light and dark mode?
+        2. **Agent status badges**: Do status indicators use distinct and
+           readable colors in both light and dark mode?
         3. **Table row hover**: Is the hover state visible in dark mode?
 
         ## Output rules
@@ -117,5 +117,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-kubernetes.yml
+++ b/.github/workflows/explore-kubernetes.yml
@@ -32,17 +32,17 @@ jobs:
         - Navigate to the Kubernetes page, select a cluster, and drill into
           a namespace. Then select a different namespace without going back to
           the top. Does the view update cleanly?
-        - Click on a pod row. Does a detail drawer open? Does it show CPU,
-          memory, and restart info? Is anything missing?
+        - Click on a pod row. Does a detail drawer open? Does it show
+          key resource metrics and pod info? Is anything missing?
         - Switch the time range to "last 15 minutes" when only one data point
           might be in range. Is there a graceful empty state?
         - Filter by node name. Does the pod list narrow correctly?
         - Try sorting the pod list by CPU utilization, memory usage, and
           restart count. Does the order change each time?
-        - Check workload grouping — are pods grouped under their Deployment
-          or StatefulSet? If a pod name doesn't match a known workload, how
-          does it appear?
-        - Look for any pods with restarts > 0. Is there a warning indicator?
+        - Check workload grouping — are pods organized by workload type?
+          How do ungrouped or unmatched pods appear?
+        - Look for pods with restart activity. Are there visual indicators
+          for pods that have restarted?
         - Switch to dark mode and check contrast on the Kubernetes page
           specifically.
         - Navigate to Kubernetes, then to another page, then back. Is the
@@ -112,9 +112,8 @@ jobs:
 
         On every run, also check these visual quality dimensions:
 
-        1. **Pod table readability**: After viewing pods, are CPU utilization
-           percentages, memory values, and restart counts formatted clearly?
-           Are units shown (e.g. "%" for CPU, "MB"/"GB" for memory)?
+        1. **Pod table readability**: After viewing pods, are resource metrics
+           formatted clearly with appropriate units?
 
         2. **Node list contrast**: Check the node list in dark mode. Are
            hostname labels and health indicators readable?
@@ -123,8 +122,8 @@ jobs:
            "last 5 minutes" to test a near-empty range. Verify the no-data
            state is visually complete with icon, title, and description.
 
-        4. **Workload grouping labels**: Are Deployment, StatefulSet, and
-           DaemonSet badges styled consistently? Are they readable in dark mode?
+        4. **Workload grouping labels**: Are workload type indicators styled
+           consistently? Are they readable in dark mode?
 
         5. **Dark mode tables**: Switch to dark mode. Navigate to the pod
            list. Are alternating row backgrounds, borders, and text all readable?
@@ -144,5 +143,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-live-es.yml
+++ b/.github/workflows/explore-live-es.yml
@@ -106,5 +106,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-logs.yml
+++ b/.github/workflows/explore-logs.yml
@@ -90,9 +90,9 @@ jobs:
         The toolbar has three view mode toggle buttons: **Lines**, **Chart**,
         and **Patterns**.
 
-        - **Lines mode** (default): Shows a table of log entries with columns.
-          Verify that @timestamp, message, log.level, service.name, host.name,
-          and other columns are visible. Does scrolling the table work?
+        - **Lines mode** (default): Shows a table of log entries with columns
+          for timestamps, messages, log levels, service names, and other
+          fields. Does scrolling the table work?
         - **Chart mode**: Shows a histogram of log volume over time (5-minute
           buckets). Are the bars rendering? Does the Y axis show counts? Are
           buckets proportionally sized? Take a screenshot in both light and
@@ -107,15 +107,15 @@ jobs:
 
         ## Sidebar field filters
 
-        The left panel shows four field sections: **service.name**, **log.level**,
-        **host.name**, and **event.dataset**. Each section lists the top 8
-        distinct values with `+` (include) and `-` (exclude) buttons.
+        The left panel shows field filter sections (typically service name,
+        log level, host name, and dataset). Each section lists top distinct
+        values with include (`+`) and exclude (`-`) buttons.
 
-        - Click the `+` button on a `log.level` value (e.g., "info"). A filter
-          chip should appear in the filter bar above the table. Does the log
-          table update to show only that level?
-        - Click the `-` button on a different value (e.g., "error"). Does an
-          **exclusion** chip appear (`NOT log.level: error`)?
+        - Click the `+` button on a value. A filter chip should appear in
+          the filter bar above the table. Does the log table update to
+          show only matching entries?
+        - Click the `-` button on a different value. Does an exclusion
+          filter appear?
         - Add multiple filters (a service name + a log level). Is the query
           composing them with AND? Check the ES|QL query in the Raw Query field
           if visible.
@@ -241,5 +241,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-metrics.yml
+++ b/.github/workflows/explore-metrics.yml
@@ -146,5 +146,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-mobile.yml
+++ b/.github/workflows/explore-mobile.yml
@@ -82,5 +82,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-profiling.yml
+++ b/.github/workflows/explore-profiling.yml
@@ -178,5 +178,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-query-lab.yml
+++ b/.github/workflows/explore-query-lab.yml
@@ -149,5 +149,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-security.yml
+++ b/.github/workflows/explore-security.yml
@@ -32,8 +32,8 @@ jobs:
         **Users page:**
         - Navigate to Users. The page uses a list-detail layout: a searchable
           list on the left and a detail panel on the right. How many users are
-          listed? Does the detail panel show username, enabled/disabled status,
-          assigned roles, and metadata?
+          listed? Does the detail panel show relevant user information
+          (status, assigned roles, metadata)?
         - Click a user in the list. Does the detail panel update? What fields
           are shown (roles, metadata)?
         - Use the search field to filter users by name.
@@ -41,14 +41,14 @@ jobs:
 
         **Roles page:**
         - Navigate to Roles. Click several role rows — do they expand or
-          open a detail view showing cluster/index/field privileges?
+          open a detail view showing privilege information?
         - Filter or search for a built-in role (e.g., "kibana_system").
           Is the privilege breakdown readable?
         - Are read-only indicator roles visually distinct from custom roles?
 
         **API Keys page:**
-        - Navigate to API Keys. Are any API keys listed? What columns does
-          the table show (name, owner, created, expiration)?
+        - Navigate to API Keys. Are any API keys listed? Does the table
+          show relevant key metadata?
         - Click an API key row — is there a detail view or expansion?
         - If no keys exist, is the empty state helpful?
 
@@ -70,10 +70,10 @@ jobs:
         **Investigate page — search and results:**
         - Type a user name visible in the suggestions (or from the Users
           page) and press Enter or click Search. Does the timeline load?
-        - Verify the results show a summary panel with event count,
-          category chips, and data source chips.
-        - Verify the timeline table shows timestamps, categories, actions,
-          outcomes, and messages.
+        - Verify the results show a summary panel with event counts and
+          category information.
+        - Verify the timeline table shows relevant event details
+          (timestamps, categories, outcomes, etc.).
         - Search for a name that does not exist. Is the "No events found"
           empty state shown with a helpful message?
         - Try special characters in the search field (e.g., names with
@@ -199,5 +199,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-services.yml
+++ b/.github/workflows/explore-services.yml
@@ -90,14 +90,13 @@ jobs:
 
         ### Overview cards
 
-        Once search results load, four summary cards appear at the top:
-        - **Total Services** (count of discovered services)
-        - **Total Requests** (aggregate request count)
-        - **Avg Latency** (weighted average across all services)
-        - **Error Rate** (aggregate error rate)
+        Once search results load, summary cards appear at the top showing
+        aggregate metrics (service count, request volume, latency, error
+        rate, etc.).
 
-        Verify that all four cards are populated with values.
-        Are the values formatted readably (e.g., "12.3 ms" not "12345 µs")?
+        Verify that the cards are populated with values and that the values
+        are formatted in human-readable units (e.g., milliseconds not raw
+        microseconds, percentages not raw decimals).
 
         ### Time range and search
 
@@ -110,17 +109,9 @@ jobs:
 
         ### Service inventory table
 
-        The table lists discovered services with these columns:
-        - **Service Name**
-        - **Requests** (total request count)
-        - **Requests trend** (sparkline, if data available)
-        - **Avg Latency** (formatted as ms or µs)
-        - **Latency trend** (sparkline, if data available)
-        - **Error Rate** (formatted as a percentage)
-        - **Error rate trend** (sparkline, if data available)
-        - **Language** (e.g., "python", "node", "java")
-        - **Environment** (e.g., "production", "staging")
-        - **Actions**
+        The table lists discovered services with columns for service name,
+        performance metrics (requests, latency, error rate), trend
+        sparklines, and service metadata (language, environment).
 
         Interactions to try:
         - Sort by **Avg Latency** descending. Are the slowest services at
@@ -160,19 +151,18 @@ jobs:
 
         ### Summary cards
 
-        The top of the Service Dashboard shows summary cards:
-        - Total requests
-        - Average latency
-        - Error rate
-        - Top error (if any)
+        The top of the Service Dashboard shows summary cards with key
+        performance metrics for the selected service (request volume,
+        latency, error rate, etc.).
 
-        Are the values consistent with what was shown in the inventory table?
+        Do the values look reasonable compared to what the inventory table
+        showed?
 
         ### Routes table
 
-        A **Top Routes** table lists the most-used HTTP routes/operations:
-        - Columns: route/operation name, request count, avg latency, error rate
-        - Sort by **Request count** descending. Are the busiest routes at top?
+        A routes table lists the most-used HTTP routes/operations with
+        performance metrics per route.
+        - Sort by request count descending. Are the busiest routes at top?
         - Sort by **Avg Latency** descending. Are the slowest routes at top?
         - Sort by **Error rate** descending. Are the most error-prone routes listed?
         - Click a column header twice — does sort direction toggle?
@@ -180,12 +170,11 @@ jobs:
 
         ### Recent Traces table
 
-        A **Recent Traces** section shows the latest trace entries for the service:
-        - Are columns (trace ID, root span, duration, status, timestamp) visible?
-        - Click a trace row — does it navigate to the Traces page filtered
-          to that service?
-        - Is there a "View all traces" or "Open in Traces" button? Click it —
-          does it navigate to Traces with the service filter pre-populated?
+        A recent traces section shows the latest trace entries for the service.
+        - Are the key trace details (ID, duration, status, timestamp) visible?
+        - Click a trace row — does it navigate to a trace detail view?
+        - Is there a way to view all traces for this service? If so, does
+          it navigate to Traces with the service filter pre-populated?
 
         ### Performance charts
 
@@ -200,8 +189,7 @@ jobs:
 
         ### Back navigation
 
-        - Click "Back to Services" or use the breadcrumb. Does it return
-          to the Service Performance page?
+        - Use the back link or breadcrumb to return to the service list.
         - Does the inventory table still show the same data on return?
 
         ---
@@ -265,5 +253,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-traces.yml
+++ b/.github/workflows/explore-traces.yml
@@ -32,20 +32,20 @@ jobs:
         - Search for traces, click into one, expand every span in the
           tree. Are parent-child relationships rendered correctly?
         - Click a trace, look at the span detail panel. Does it show
-          all expected fields (duration, service name, status)?
+          key span fields (duration, service name, status, etc.)?
         - Switch between the span tree and service map views multiple
           times. Does the visualization re-render each time?
-        - Click "Open in Query Lab" from a trace. Does the pivot carry
-          context (trace ID, service name) into the query?
+        - Look for a way to pivot from a trace into Query Lab. Does the
+          pivot carry context (trace ID, service name) into the query?
         - Go back from Query Lab to Traces. Does the trace list still
           show your previous search results?
         - Search for traces, then clear the search. Does the UI reset?
         - Use the **service name filter** to narrow to one specific service.
           Does the trace list update? Clear the filter — does the full list
           return?
-        - Use the **Error / Success status chips** to filter for only error traces.
+        - Use the status filter controls to filter for only error traces.
           Are the filtered results actually errors? Click one to verify.
-        - Use the **min/max duration inputs** to filter for traces over 100ms.
+        - Use the duration filter to narrow to traces over 100ms.
           Are the results within the expected range?
         - Try clicking on service map nodes. Do they highlight or show
           detail? Try edges too.
@@ -53,10 +53,9 @@ jobs:
           tree, then navigate away and come back. Is state preserved?
         - Check what happens with traces that have many spans. Does the
           tree scroll? Are deeply nested spans indented correctly?
-        - Navigate to the **Services (Service Inventory)** page from the
-          sidebar. Does the table list services with request rate, error
-          rate, and latency columns? Click a service row — does it navigate
-          to a filtered trace search for that service?
+        - Navigate to the **Services** page from the sidebar. Does the
+          table list services with performance metrics? Click a service
+          row — does it navigate to a detail view or filtered trace search?
         - On the Services page, sort by error rate descending. Are the
           services with the most errors at the top?
         - Look for any console errors during trace and service navigation.
@@ -122,14 +121,13 @@ jobs:
         On every run, also check these visual quality dimensions:
 
         1. **Filter bar height consistency**: Measure the bounding rect heights
-           of every control in the Traces filter bar (service name field,
-           min/max duration fields, Apply button, time selector, Error/OK
-           chips). All must be the same height (within 4px). Use
-           `browser_console_execute` to measure bounding rect heights.
+           of the controls in the Traces filter bar (inputs, buttons,
+           selectors, chips). All should be the same height (within 4px).
+           Use `browser_console_execute` to measure bounding rect heights.
 
         2. **Dark mode contrast**: Switch to dark mode. Take a screenshot of
            the traces list. Are column headers visible? Are status badges
-           readable? Is the "Trace Search" label contrast sufficient?
+           readable? Are page and section labels contrast-sufficient?
 
         3. **Service map empty state**: Navigate to the service map view with
            no traces loaded. Is there a helpful empty state with an icon and
@@ -154,5 +152,10 @@ jobs:
           page/location, what you tried, what you expected, what actually
           happened, and a screenshot. A thorough issue typically has 3-10
           findings.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a bug. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/.github/workflows/explore-ux-papercuts.yml
+++ b/.github/workflows/explore-ux-papercuts.yml
@@ -191,5 +191,10 @@ jobs:
           make you distrust the product or give up on a task).
         - If everything you tried was genuinely smooth and consistent
           (unlikely), do not open an issue.
+        - **Prompt accuracy**: If the UI differs from what this prompt
+          describes (e.g., a title, label, or layout has changed) but the
+          UI itself is fine, do NOT file that as a papercut. Instead, add a
+          **"Prompt Suggestions"** section at the end of your issue listing
+          what this prompt should say instead to match the current UI.
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Addresses the root cause of issue #1787 where an explore agent filed UI copy mismatches as bugs because the prompt contained exact quoted strings that the agent treated as a test specification.

- **Softened literal UI strings** in the workflows with the most literal UI copy (notably `explore-add-data.yml`, `explore-services.yml`, `explore-traces.yml`, `explore-cluster-overview.yml`, `explore-security.yml`, `explore-kubernetes.yml`, `explore-fleet-add-data.yml`, and `explore-logs.yml`) — replaced exact quoted titles, column lists, button labels, and error messages with descriptive navigational guidance
- **Added "Prompt Suggestions" output rule** to all 18 workflows — when the UI differs from what the prompt describes but the UI is fine, agents add a "Prompt Suggestions" section to their issue instead of filing it as a bug

### Heaviest rewrites
| File | What changed |
|---|---|
| `explore-add-data.yml` | Rewrote all 3 step sections to remove exact title/subtitle/description strings; softened API key, verification, and CTA descriptions |
| `explore-services.yml` | Replaced enumerated column lists and exact format specs with general descriptions |
| `explore-traces.yml` | Softened filter bar component names and exact label references |
| `explore-cluster-overview.yml` | Generalized info card field list and clickable card specs |
| `explore-security.yml` | Softened enumerated field expectations across Users, Roles, API Keys, and Investigate pages |
| `explore-kubernetes.yml` | Generalized pod detail fields, workload grouping labels, and metric format specs |
| `explore-fleet-add-data.yml` | Softened exact agent status values |
| `explore-logs.yml` | Generalized sidebar field filter names and filter chip text |

## Test plan

- [ ] Trigger `explore-add-data` manually — verify the agent no longer files title/subtitle mismatches as bugs
- [ ] Check that any filed issue includes a "Prompt Suggestions" section if UI copy has drifted
- [ ] Verify agents still find real bugs (the prompts still describe *what to test*, just not exact strings to match)

🤖 Generated with [Claude Code]((claude.com/redacted)

---
The body of this PR [is automatically managed](https://ela.st/github-ai-tools) by the [Update PR Body workflow](https://github.com/elastic/ai-github-actions-playground/actions/runs/22697097316).

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22697097316, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions-playground/actions/runs/22697097316 -->