### PR TITLE
fix(security): replace deprecated manage_data_stream privilege

### DIFF
--- a/peek/scripts/elasticsearch-mocks.mjs
+++ b/peek/scripts/elasticsearch-mocks.mjs
@@ -102,7 +102,7 @@ const DEFAULT_MOCK_DATA = {
   ingestNodeStats: { nodes: { n1: { ingest: { total: { count: 1000, failed: 0 } } } } },
   hasPrivileges: {
     cluster: {
-      manage_data_stream: true,
+      manage: true,
       read_security: true,
       manage_security: false,
       manage_own_api_key: true,

--- a/peek/src/services/es/client.ts
+++ b/peek/src/services/es/client.ts
@@ -571,7 +571,7 @@ export class ElasticsearchClient {
         method: "POST",
         body: JSON.stringify({
           cluster: [
-            "manage_data_stream",
+            "manage",
             "read_security",
             "manage_security",
             "manage_own_api_key",
@@ -587,7 +587,7 @@ export class ElasticsearchClient {
         response.cluster?.["manage_own_api_key"] || response.cluster?.["manage_api_key"],
       );
       return {
-        canManageDataStreams: response.cluster?.["manage_data_stream"] ?? false,
+        canManageDataStreams: response.cluster?.["manage"] ?? false,
         canCreateApiKeys,
         canReadSecurityUsers: canReadSecurity,
         canReadSecurityRoles: canReadSecurity,

--- a/peek/tests/component/WelcomeScreen.test.tsx
+++ b/peek/tests/component/WelcomeScreen.test.tsx
@@ -71,7 +71,7 @@ describe("WelcomeScreen", () => {
         new Response(JSON.stringify({ cluster_name: "demo" }), { status: 200 }),
       )
       .mockResolvedValueOnce(
-        new Response(JSON.stringify({ cluster: { manage_data_stream: true } }), { status: 200 }),
+        new Response(JSON.stringify({ cluster: { manage: true } }), { status: 200 }),
       );
 
     const user = userEvent.setup();

--- a/peek/tests/e2e/love-audit.spec.ts
+++ b/peek/tests/e2e/love-audit.spec.ts
@@ -238,7 +238,7 @@ const INGEST_PIPELINES = {
 
 const HAS_PRIVILEGES = {
   cluster: {
-    manage_data_stream: true,
+    manage: true,
     read_security: true,
     manage_security: false,
     manage_own_api_key: true,

--- a/peek/tests/unit/elasticsearchClient.test.ts
+++ b/peek/tests/unit/elasticsearchClient.test.ts
@@ -583,7 +583,7 @@ describe("isElasticsearchError", () => {
 describe("getCapabilities", () => {
   it("returns canManageDataStreams: true when cluster privilege is granted", async () => {
     const fetchSpy = mockFetchOnce(
-      { cluster: { manage_data_stream: true, read_security: true } },
+      { cluster: { manage: true, read_security: true } },
       { status: 200 },
     );
     vi.stubGlobal("fetch", fetchSpy);
@@ -597,7 +597,7 @@ describe("getCapabilities", () => {
   });
 
   it("returns canManageDataStreams: false when cluster privilege is denied", async () => {
-    const fetchSpy = mockFetchOnce({ cluster: { manage_data_stream: false } }, { status: 200 });
+    const fetchSpy = mockFetchOnce({ cluster: { manage: false } }, { status: 200 });
     vi.stubGlobal("fetch", fetchSpy);
 
     const client = makeClient({ apiKey: "key" });
@@ -684,7 +684,7 @@ describe("getCapabilities", () => {
   });
 
   it("POSTs to /_security/user/_has_privileges with the expected body", async () => {
-    const fetchSpy = mockFetchOnce({ cluster: { manage_data_stream: false } }, { status: 200 });
+    const fetchSpy = mockFetchOnce({ cluster: { manage: false } }, { status: 200 });
     vi.stubGlobal("fetch", fetchSpy);
 
     const client = makeClient();
@@ -695,7 +695,7 @@ describe("getCapabilities", () => {
     expect(init.method).toBe("POST");
     expect(JSON.parse(init.body as string)).toEqual({
       cluster: [
-        "manage_data_stream",
+        "manage",
         "read_security",
         "manage_security",
         "manage_own_api_key",


### PR DESCRIPTION
## Problem
Login fails on the public demo with:
```
unknown cluster privilege [manage_data_stream]. a privilege must be either one of the predefined cluster privilege names...
```

The `manage_data_stream` cluster privilege was removed in newer Elasticsearch versions.

## Solution
Replace `manage_data_stream` with `manage` in the `_has_privileges` capability check. The `manage` cluster privilege is valid and covers data stream management.

Made with [Cursor](https://cursor.com)