### PR TITLE
fix(system): preserve global stream sorting and node detail state messaging

### DIFF
--- a/peek/src/components/DataStreamsPage.tsx
+++ b/peek/src/components/DataStreamsPage.tsx
@@ -236,6 +236,16 @@ export default function DataStreamsPage() {
   ]);
 
   const groupedRows = useMemo(() => {
+    if (streamSortField !== "name") {
+      return filteredStreams.map((stream) => ({
+        kind: "stream" as const,
+        key: `stream:${stream.name}`,
+        depth: 0,
+        name: stream.name,
+        stream,
+      }));
+    }
+
     const grouped = new Map<string | null, typeof filteredStreams>();
     for (const stream of filteredStreams) {
       const group = streamGroupName(stream.name);
@@ -263,7 +273,7 @@ export default function DataStreamsPage() {
       }
     }
     return rows;
-  }, [filteredStreams, expandedGroups]);
+  }, [filteredStreams, expandedGroups, streamSortField]);
 
   const streamMetrics = useMemo(
     () =>

--- a/peek/src/components/NodeDetailPage.tsx
+++ b/peek/src/components/NodeDetailPage.tsx
@@ -23,6 +23,8 @@ export default function NodeDetailPage() {
   const data = result.status === "success" ? result.data : null;
   const loading = result.status === "loading";
   const error = result.status === "error" ? result.error : null;
+  const nodeDataUnavailable =
+    partialErrors.includes("nodes") && partialErrors.includes("node stats");
 
   const details = useMemo(() => {
     if (!decodedNodeId || !data) return null;
@@ -80,10 +82,14 @@ export default function NodeDetailPage() {
         </Alert>
       )}
 
-      {!details ? (
+      {error ? null : !details ? (
         <EmptyState
-          heading="Node not found"
-          description="The selected node could not be found in current cluster node data."
+          heading={nodeDataUnavailable ? "Node data unavailable" : "Node not found"}
+          description={
+            nodeDataUnavailable
+              ? "Node APIs are unavailable for this cluster or current permissions."
+              : "The selected node could not be found in current cluster node data."
+          }
         />
       ) : (
         <Paper variant="outlined" sx={{ p: 2 }}>

--- a/peek/tests/component/DataStreamsPage.test.tsx
+++ b/peek/tests/component/DataStreamsPage.test.tsx
@@ -586,4 +586,31 @@ describe("DataStreamsPage", () => {
     expect(within(dataRowsDesc[0]).getByText("logs-b")).toBeInTheDocument();
     expect(within(dataRowsDesc[1]).getByText("logs-a")).toBeInTheDocument();
   });
+
+  it("disables grouped rendering when sorting by Docs", async () => {
+    const user = userEvent.setup();
+
+    getDataStreamsMock.mockResolvedValue({
+      data_streams: [
+        { name: "logs-a", status: "GREEN", generation: 1, template: "logs", indices: [{}] },
+        { name: "logs-b", status: "GREEN", generation: 1, template: "logs", indices: [{}] },
+      ],
+    });
+    getFieldCapsMock.mockResolvedValue({ fields: {} });
+
+    render(
+      <MemoryRouter>
+        <NuqsTestingAdapter hasMemory>
+          <DataStreamsPage />
+        </NuqsTestingAdapter>
+      </MemoryRouter>,
+    );
+
+    // Name sort groups matching prefixes by default.
+    expect(await screen.findByLabelText(/collapse group logs/i)).toBeInTheDocument();
+
+    // Non-name sort should render a flat list and hide group controls.
+    await user.click(screen.getByRole("button", { name: /^docs$/i }));
+    expect(screen.queryByLabelText(/group logs/i)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary
- Keep Data Streams grouped rows only for Name sorting so Docs/Size sorts preserve true global ordering.
- Prevent `NodeDetailPage` from showing a misleading "Node not found" empty state when the page already has a hard error or node APIs are unavailable.
- Add a component regression test proving Docs sort disables grouped rendering.

## Test plan
- [x] `cd peek && npx vitest run --config vitest.config.ts tests/component/DataStreamsPage.test.tsx`
- [x] `cd /Users/bill.easton/repos/ai-github-actions-playground && make lint BASE=HEAD~1`

Made with [Cursor](https://cursor.com)