### PR TITLE
fix(data-streams): make list table full-width with flyout details

### DIFF
--- a/peek/src/components/DataStreamsPage.tsx
+++ b/peek/src/components/DataStreamsPage.tsx
@@ -541,9 +541,8 @@ export default function DataStreamsPage() {
               variant="outlined"
               sx={{
                 display: "flex",
-                flexShrink: 0,
                 flexDirection: "column",
-                width: 480,
+                width: "100%",
                 minHeight: 0,
               }}
             >


### PR DESCRIPTION
## Summary
- Expand the Data Streams list panel to full width now that stream details render in a right-side flyout.
- Remove the fixed-width/forced-shrink styling that constrained the table area.
- Align Data Streams layout behavior with Indices, where details no longer consume inline table space.

## Test plan
- [x] `cd peek && npx vitest run --config vitest.config.ts tests/component/DataStreamsPage.test.tsx`

Made with [Cursor](https://cursor.com)