### PR TITLE
fix(ci): grant issues:write permission for pr-labeler workflow

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -6,7 +6,7 @@ on:
 permissions:
   actions: read
   contents: read
-  issues: read
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
## Summary

- The called workflow `gh-aw-pr-labeler.lock.yml` requires `issues: write` for its `conclusion` and `safe_outputs` jobs
- `pr-labeler.yml` only granted `issues: read`, causing workflow validation to fail
- Changed `issues: read` → `issues: write` on line 9

## Test plan

- [ ] Verify the PR Labeler workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)