### PR TITLE
feat: extend address-pr-review-feedback to also fix CI failures

### DIFF
--- a/.github/workflows/address-pr-review-feedback.yml
+++ b/.github/workflows/address-pr-review-feedback.yml
@@ -40,6 +40,22 @@ jobs:
 
         When in doubt, reply to the review thread explaining why you're skipping
         the change rather than making a potentially incorrect fix.
+
+        ## CI failures
+
+        After addressing review threads, also check the PR's CI status:
+
+        1. Look at the failing checks on the PR (use the GitHub API or gh CLI).
+        2. Read any bot comments on the PR — the PR Actions Detective agent posts
+           comments explaining what caused CI to fail and how to fix it. These
+           comments are your primary guide for fixing CI.
+        3. If CI is failing and the bot comment (or the check logs) point to a
+           clear, straightforward fix (e.g. a lint error, a type error, a failing
+           unit test, a missing import), apply the fix.
+        4. Apply the same scope rules as review feedback: fix simple, obvious CI
+           failures only. Do NOT attempt complex logic rewrites to make tests pass.
+        5. If you fix a CI failure, briefly describe what you changed and why in
+           your commit message.
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}
       EXTRA_COMMIT_GITHUB_TOKEN: ${{ secrets.COMMIT_GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Extends the **Address PR Review Feedback** agent's instructions to also handle failing CI checks on a PR, not just review thread feedback.

### What changed

Added a **CI failures** section to `additional-instructions` that tells the agent to:

1. Check the PR's failing checks after addressing review threads
2. Read bot comments on the PR — the PR Actions Detective posts comments explaining what caused CI failures and how to fix them
3. Apply simple, obvious fixes (lint errors, type errors, failing unit tests) using the same scope rules as review feedback
4. Describe CI fixes in the commit message

### Scope rules unchanged

The agent still won't attempt architectural changes, complex logic rewrites, or anything requiring deep context — same guardrails as before, just applied to CI failures too.