### PR TITLE
fix: flaky multi-step component tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ test-unit-staged:
 	@echo "Running unit tests related to staged JS/TS files in peek/..."
 	@STAGED=$$(git diff --cached --name-only --diff-filter=ACMR -- 'peek' | grep -E '^peek/.*\.(ts|tsx|js|jsx)$$' | sed 's#^peek/##' || true); \
 	if [ -n "$$STAGED" ]; then \
-		(cd $(PEEK_DIR) && echo "$$STAGED" | tr '\n' '\0' | xargs -0 npx vitest related --run --passWithNoTests); \
+		(cd $(PEEK_DIR) && echo "$$STAGED" | tr '\n' '\0' | xargs -0 npx vitest related --run --passWithNoTests --pool=forks --poolOptions.forks.maxForks=4); \
 	else \
 		echo "No staged JS/TS files under peek/ — skipping unit tests."; \
 	fi

--- a/peek/tests/component/App.test.tsx
+++ b/peek/tests/component/App.test.tsx
@@ -173,7 +173,8 @@ describe("App shell visibility", () => {
   });
 
   it("navigates to settings when Configure key is clicked", async () => {
-    const user = userEvent.setup();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     useConnectionStore.getState().setConnected(true);
     useLLMStore.getState().setApiKey("");
 
@@ -184,9 +185,11 @@ describe("App shell visibility", () => {
       </MemoryRouter>,
     );
 
-    await user.click(screen.getByRole("button", { name: /configure key/i }));
+    const btn = await screen.findByRole("button", { name: /configure key/i });
+    await user.click(btn);
 
     expect(screen.getByTestId("location")).toHaveTextContent("/settings");
+    vi.useRealTimers();
   });
 
   it("keeps the LLM key banner hidden when already dismissed in session", () => {
@@ -287,7 +290,8 @@ describe("App shell visibility", () => {
   });
 
   it("navigates to /dashboards after resetting all state from a dashboard view", async () => {
-    const user = userEvent.setup();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
     useConnectionStore.getState().setConnected(true);
 
     render(
@@ -300,7 +304,8 @@ describe("App shell visibility", () => {
     expect(screen.getByTestId("location")).toHaveTextContent("/dashboards/stale-dashboard-id");
 
     // Open Settings menu and click "Reset All State…"
-    await user.click(screen.getByRole("button", { name: "Settings" }));
+    const settingsBtn = await screen.findByRole("button", { name: "Settings" });
+    await user.click(settingsBtn);
     await user.click(await screen.findByRole("menuitem", { name: /reset all state/i }));
 
     // Click the "Reset" button to confirm
@@ -308,5 +313,6 @@ describe("App shell visibility", () => {
 
     // After reset, the URL should be /dashboards (not the stale dashboard ID)
     await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent(/^\/dashboards$/));
+    vi.useRealTimers();
   });
 });

--- a/peek/tests/component/DataStreamsPage.test.tsx
+++ b/peek/tests/component/DataStreamsPage.test.tsx
@@ -450,7 +450,8 @@ describe("DataStreamsPage", () => {
   });
 
   it("clears the Field Stats panel when a different stream is selected", async () => {
-    const user = userEvent.setup();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
 
     getDataStreamsMock.mockResolvedValue({
       data_streams: [
@@ -486,6 +487,7 @@ describe("DataStreamsPage", () => {
         "false",
       );
     });
+    vi.useRealTimers();
   });
 
   it("navigates to Console with a data stream draft when Inspect in Console is clicked", async () => {


### PR DESCRIPTION
## Summary

- Three flaky multi-step component tests were stabilized by switching to fake timers with `userEvent.setup({ advanceTimers: vi.advanceTimersByTime })` and restoring real timers after each test.
- Replaced eager `getByRole` clicks with `findByRole` in App tests where controls can appear asynchronously.
- Updated `test-unit-staged` in `Makefile` to run `vitest related` with fork pool limits (`--pool=forks --poolOptions.forks.maxForks=4`) to reduce pre-commit flakiness.

**Tests fixed:**
- `App shell visibility > navigates to settings when Configure key is clicked`
- `App shell visibility > navigates to /dashboards after resetting all state from a dashboard view`
- `DataStreamsPage > clears the Field Stats panel when a different stream is selected`

## Test plan

- [x] All 35 tests in `App.test.tsx` and `DataStreamsPage.test.tsx` pass
- [ ] CI passes

---
The body of this PR [is automatically managed](https://ela.st/github-ai-tools) by the [Update PR Body workflow](https://github.com/elastic/ai-github-actions-playground/actions/runs/22813495374).

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gpt-5.3-codex, id: 22813495374, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions-playground/actions/runs/22813495374 -->