### PR TITLE
fix(ci): reduce test parallelism and fix oxfmt formatting

### DIFF
--- a/peek/src/docs/keyboard-shortcuts.md
+++ b/peek/src/docs/keyboard-shortcuts.md
@@ -4,12 +4,12 @@ Elastic Peek includes keyboard shortcuts and productivity tips to help you navig
 
 ## Keyboard shortcuts
 
-| Shortcut | Action |
-|---|---|
-| `Ctrl/Cmd + K` | Open the command palette |
-| `Ctrl/Cmd + Shift + A` | Toggle the AI Assistant drawer |
-| `Ctrl/Cmd + Enter` | Run the current ES\|QL query (Query Lab, Panel Editor, Logs Explorer) |
-| `Arrow Up / Down` | Navigate between rows in Query Lab while the row inspector is open |
+| Shortcut               | Action                                                                |
+| ---------------------- | --------------------------------------------------------------------- |
+| `Ctrl/Cmd + K`         | Open the command palette                                              |
+| `Ctrl/Cmd + Shift + A` | Toggle the AI Assistant drawer                                        |
+| `Ctrl/Cmd + Enter`     | Run the current ES\|QL query (Query Lab, Panel Editor, Logs Explorer) |
+| `Arrow Up / Down`      | Navigate between rows in Query Lab while the row inspector is open    |
 
 ## Command palette
 

--- a/peek/src/docs/visualizations.md
+++ b/peek/src/docs/visualizations.md
@@ -58,14 +58,14 @@ Embedded queries respect the dashboard time range and parameter values (using `?
 
 ## Choosing the right type
 
-| Data shape | Recommended type |
-|---|---|
-| Time-series trend | Time Series |
-| Category comparison | Bar Chart |
-| Distribution breakdown | Pie Chart |
-| Two-dimensional density | Heatmap |
-| Correlation of two metrics | Scatter |
-| Value frequency | Histogram |
-| Single KPI value | Stat or Gauge |
-| Detailed rows | Table |
-| Annotations and notes | Markdown |
+| Data shape                 | Recommended type |
+| -------------------------- | ---------------- |
+| Time-series trend          | Time Series      |
+| Category comparison        | Bar Chart        |
+| Distribution breakdown     | Pie Chart        |
+| Two-dimensional density    | Heatmap          |
+| Correlation of two metrics | Scatter          |
+| Value frequency            | Histogram        |
+| Single KPI value           | Stat or Gauge    |
+| Detailed rows              | Table            |
+| Annotations and notes      | Markdown         |

--- a/peek/vitest.config.ts
+++ b/peek/vitest.config.ts
@@ -13,6 +13,12 @@ export default defineConfig({
     environmentMatchGlobs: [["tests/unit/**/*.test.ts", "node"]],
     setupFiles: ["./vitest.setup.ts"],
     css: false,
+    pool: "forks",
+    poolOptions: {
+      forks: {
+        maxForks: 4,
+      },
+    },
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],


### PR DESCRIPTION
## Summary
- **Test timeouts**: Limit vitest to `pool: "forks"` with `maxForks: 4` in `vitest.config.ts` to prevent CPU contention on 2-core CI runners that was causing the "navigates to /dashboards after resetting all state" test to exceed 5s
- **Lint failures**: Fix markdown table formatting in `keyboard-shortcuts.md` and `visualizations.md` that caused `oxfmt --check` to fail since the docs overhaul PR (#2012)

## Test plan
- [ ] CI lint step passes (oxfmt no longer reports formatting issues)
- [ ] CI unit test step passes (no more flaky timeouts from parallel contention)

🤖 Generated with [Claude Code](https://claude.com/claude-code)