### PR TITLE
fix: resolve CI timeouts and type errors on main

### DIFF
--- a/peek/src/components/TemplatesPage.tsx
+++ b/peek/src/components/TemplatesPage.tsx
@@ -129,15 +129,25 @@ export default function TemplatesPage() {
     [compTplSortField, compTplSortDir, setUrlState],
   );
 
-  // Detail flyover
-  const [selectedTemplateName, setSelectedTemplateName] = useState<string | null>(null);
+  // Detail flyover – use a typed ref so same-named index/component templates
+  // don't collide in the drawer.
+  const [selectedTemplateRef, setSelectedTemplateRef] = useState<{
+    kind: "index" | "component";
+    name: string;
+  } | null>(null);
   const selectedTemplate = useMemo(
-    () => indexTemplates.find((t) => t.name === selectedTemplateName) ?? null,
-    [indexTemplates, selectedTemplateName],
+    () =>
+      selectedTemplateRef?.kind === "index"
+        ? (indexTemplates.find((t) => t.name === selectedTemplateRef.name) ?? null)
+        : null,
+    [indexTemplates, selectedTemplateRef],
   );
   const selectedComponentTemplate = useMemo(
-    () => componentTemplates.find((t) => t.name === selectedTemplateName) ?? null,
-    [componentTemplates, selectedTemplateName],
+    () =>
+      selectedTemplateRef?.kind === "component"
+        ? (componentTemplates.find((t) => t.name === selectedTemplateRef.name) ?? null)
+        : null,
+    [componentTemplates, selectedTemplateRef],
   );
   const simulatedTemplate = useSimulatedIndexTemplate(selectedTemplate?.name ?? null);
 
@@ -369,15 +379,17 @@ export default function TemplatesPage() {
                   <TableRow
                     key={tpl.name}
                     hover
-                    selected={tpl.name === selectedTemplateName}
+                    selected={
+                      selectedTemplateRef?.kind === "index" && tpl.name === selectedTemplateRef.name
+                    }
                     tabIndex={0}
                     role="button"
                     aria-label={`Open template details for ${tpl.name}`}
-                    onClick={() => setSelectedTemplateName(tpl.name)}
+                    onClick={() => setSelectedTemplateRef({ kind: "index", name: tpl.name })}
                     onKeyDown={(event) => {
                       if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
                         event.preventDefault();
-                        setSelectedTemplateName(tpl.name);
+                        setSelectedTemplateRef({ kind: "index", name: tpl.name });
                       }
                     }}
                     sx={{ cursor: "pointer" }}
@@ -483,11 +495,11 @@ export default function TemplatesPage() {
                     tabIndex={0}
                     role="button"
                     aria-label={`View component template ${ct.name}`}
-                    onClick={() => setSelectedTemplateName(ct.name)}
+                    onClick={() => setSelectedTemplateRef({ kind: "component", name: ct.name })}
                     onKeyDown={(event) => {
                       if (event.key === "Enter" || event.key === " " || event.key === "Spacebar") {
                         event.preventDefault();
-                        setSelectedTemplateName(ct.name);
+                        setSelectedTemplateRef({ kind: "component", name: ct.name });
                       }
                     }}
                     sx={{ cursor: "pointer" }}
@@ -542,7 +554,7 @@ export default function TemplatesPage() {
       <Drawer
         anchor="right"
         open={Boolean(selectedTemplate || selectedComponentTemplate)}
-        onClose={() => setSelectedTemplateName(null)}
+        onClose={() => setSelectedTemplateRef(null)}
         PaperProps={{
           sx: {
             width: { xs: "100%", md: 560 },
@@ -565,7 +577,7 @@ export default function TemplatesPage() {
               <IconButton
                 size="small"
                 aria-label="Close template details"
-                onClick={() => setSelectedTemplateName(null)}
+                onClick={() => setSelectedTemplateRef(null)}
               >
                 <CloseIcon fontSize="small" />
               </IconButton>
@@ -682,7 +694,7 @@ export default function TemplatesPage() {
               <IconButton
                 size="small"
                 aria-label="Close template details"
-                onClick={() => setSelectedTemplateName(null)}
+                onClick={() => setSelectedTemplateRef(null)}
               >
                 <CloseIcon fontSize="small" />
               </IconButton>

--- a/peek/tests/component/App.test.tsx
+++ b/peek/tests/component/App.test.tsx
@@ -290,8 +290,7 @@ describe("App shell visibility", () => {
   });
 
   it("navigates to /dashboards after resetting all state from a dashboard view", async () => {
-    vi.useFakeTimers({ shouldAdvanceTime: true });
-    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    const user = userEvent.setup();
     useConnectionStore.getState().setConnected(true);
 
     render(
@@ -313,6 +312,5 @@ describe("App shell visibility", () => {
 
     // After reset, the URL should be /dashboards (not the stale dashboard ID)
     await waitFor(() => expect(screen.getByTestId("location")).toHaveTextContent(/^\/dashboards$/));
-    vi.useRealTimers();
   });
 });


### PR DESCRIPTION
This fixes a timeout in `App.test.tsx` by removing `vi.useFakeTimers`, which was causing `userEvent` to hang. It also resolves a TypeScript compilation error in `TemplatesPage.tsx` that somehow ended up in main, preventing any commits.