### PR TITLE
ci: configure React sweepers as pure auditors

### DIFF
--- a/.github/workflows/react-performance-sweeper.yml
+++ b/.github/workflows/react-performance-sweeper.yml
@@ -17,7 +17,7 @@ jobs:
       title-prefix: "[performance-sweeper]"
       additional-instructions: |
         Focus your investigation on a single, pervasive React rendering performance anti-pattern across the entire codebase (Elastic Peek).
-        You are a "Sweeper". Do not stop at finding 2-3 isolated bugs. Your job is to identify one specific type of performance leak and refactor EVERY instance of it across the repository in a single, comprehensive Pull Request.
+        You are a "Sweeper". Do not stop at finding 2-3 isolated bugs. Your job is to identify one specific type of performance leak and file a comprehensive report detailing EVERY instance of it across the repository so that an engineer can execute the fix.
 
         ## How to sweep:
         1. Audit the codebase for systemic performance issues. Examples include:
@@ -25,11 +25,11 @@ jobs:
            - Synchronous filtering of large tables blocking user inputs (missing `useTransition` or `useDeferredValue`).
            - Derived state anti-patterns (using `useEffect` to watch State A and `setState(B)` instead of deriving during render).
         2. Identify the single anti-pattern that occurs most frequently.
-        3. Execute a sweeping pass to fix every instance of that specific anti-pattern.
-        4. Run `npm run typecheck` and `vitest` to ensure no regressions.
+        3. Execute a sweeping pass to find EVERY instance of that specific anti-pattern in the codebase.
+           4. File an issue that explains the anti-pattern, the correct fix, and an exhaustive checklist of all file paths and line numbers that need to be updated.
 
         ## Output rules
-        - Open a PR fixing the pervasive pattern. If you cannot open a PR, file an issue detailing the extent of the performance anti-pattern and the necessary fixes.
+        - File a single issue containing the explanation of the fix and an exhaustive checklist of every file/location that needs to be updated.
       setup-commands: "cd peek && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm ci"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}

--- a/.github/workflows/react-ui-boilerplate-sweeper.yml
+++ b/.github/workflows/react-ui-boilerplate-sweeper.yml
@@ -17,7 +17,7 @@ jobs:
       title-prefix: "[ui-boilerplate-sweeper]"
       additional-instructions: |
         Focus your investigation on repetitive UI markup, CSS gymnastics, and layout boilerplate across the entire codebase (Elastic Peek). 
-        You are a "Sweeper". Do not stop at finding 2-3 isolated bugs. Your job is to identify a single, pervasive UI anti-pattern and refactor EVERY instance of it across the repository in a single, comprehensive Pull Request.
+        You are a "Sweeper". Do not stop at finding 2-3 isolated bugs. Your job is to identify a single, pervasive UI anti-pattern and file a comprehensive report detailing EVERY instance of it across the repository so that an engineer can execute the refactor.
 
         All components live under `peek/src/components/`. 
 
@@ -25,11 +25,11 @@ jobs:
         1. Audit the codebase for common structural repetitions. For example: Do we copy-paste the exact same `<Box sx={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}>` 100 times instead of having a `<ScrollableLayout>`? Do we manually type `<Alert severity="error">{error}</Alert>` 50 times instead of using a unified wrapper? Do we have repetitive drawer/flyout scaffolding?
         2. Identify the worst offender.
         3. Design a single, clean React primitive to abstract it.
-        4. Execute a sweeping pass to replace the boilerplate with your new primitive everywhere it occurs.
-        5. Verify the app still builds and passes tests.
+        4. Execute a sweeping pass to find EVERY occurrence of the boilerplate in the codebase.
+        5. File an issue that clearly defines the new primitive and lists the exact file paths and line numbers of all instances that need to be replaced.
 
         ## Output rules
-        - Open a PR fixing the pervasive pattern. If you cannot open a PR, file an issue detailing the extent of the repetition and the proposed primitive.
+        - File a single issue containing the proposed architectural primitive and an exhaustive checklist of every file/location that needs to be updated.
       setup-commands: "cd peek && PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1 ELECTRON_SKIP_BINARY_DOWNLOAD=1 npm ci"
     secrets:
       COPILOT_GITHUB_TOKEN: ${{ secrets.COPILOT_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR configures the new `react-ui-boilerplate-sweeper` and `react-performance-sweeper` workflows to act as pure auditors. 

Instead of opening Pull Requests, they are now instructed to:
1. Identify a single, pervasive architectural anti-pattern.
2. File a comprehensive issue with an exhaustive checklist of every occurrence in the codebase.
3. Provide a clear design for the proposed fix/primitive.

This allows for a 'tracking issue' style workflow where an engineer or a targeted bot can execute the refactor with full visibility into the scope.