### PR TITLE
fix(ci): satisfy reusable workflow permission requirements

### DIFF
--- a/.github/workflows/address-merge-conflicts.yml
+++ b/.github/workflows/address-merge-conflicts.yml
@@ -79,7 +79,9 @@ jobs:
     needs: detect-conflicted-prs
     if: needs.detect-conflicted-prs.outputs.count != '0'
     permissions:
+      actions: read
       contents: write
+      discussions: write
       issues: write
       pull-requests: write
     strategy:


### PR DESCRIPTION
## Summary
- add `actions: read` to the `address-conflicts` job permissions in `address-merge-conflicts.yml`
- add `discussions: write` to the same job so nested reusable-workflow jobs can request required scopes
- keep all existing behavior unchanged; this is a workflow validation/permissions fix only

## Test plan
- [ ] Confirm workflow file validates with no permission-resolution errors
- [ ] Trigger `Address Merge Conflicts` via `workflow_dispatch` and verify job starts
- [ ] Confirm reusable workflow call reaches execution (no nested permission failures)

Made with [Cursor](https://cursor.com)