### PR TITLE
refactor(ci): make PR control panel items config-driven

### DIFF
--- a/.github/workflows/pr-control-panel.yml
+++ b/.github/workflows/pr-control-panel.yml
@@ -63,7 +63,7 @@ jobs:
               if (lines.length === 0) return [];
               return lines.map((line) => {
                 const parts = line.split(CONFIG_DELIMITER).map((part) => part.trim());
-                if (parts.length < 5) {
+                if (parts.length !== 5) {
                   throw new Error(
                     `Invalid ${configName} line (expected 5 fields): ${line}`,
                   );
@@ -157,9 +157,9 @@ jobs:
             }
 
             async function ensureControlLabels() {
-              for (const item of ITEMS) {
-                await ensureLabel(item.label, item.color, item.description);
-              }
+              await Promise.all(
+                ITEMS.map((item) => ensureLabel(item.label, item.color, item.description)),
+              );
             }
 
             async function listComments(issueNumber) {


### PR DESCRIPTION
## Summary
- move PR control-panel toggle definitions into a single multiline `CONTROL_PANEL_ITEMS` config
- parse that config in-script to generate checkbox rows, tooltips, hidden stable keys, label metadata, and sync behavior
- keep stable hidden keys tied to label names (``) so text/title changes cannot break parsing

## Test plan
- [ ] Open a PR and verify the control panel renders all configured items from `CONTROL_PANEL_ITEMS`
- [ ] Toggle each checkbox and confirm the corresponding `no-*` label is added/removed
- [ ] Edit visible titles/tooltips only and confirm label sync still works (keyed by hidden label key)
- [ ] Confirm no-op edits do not trigger unnecessary comment updates

Made with [Cursor]((cursor.com/redacted))

---
The body of this PR is automatically managed by the workflow runtime.

---
The body of this PR [is automatically managed](https://ela.st/github-ai-tools) by the [Update PR Body workflow](https://github.com/elastic/ai-github-actions-playground/actions/runs/22832477226).

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gemini-3-flash, id: 22832477226, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions-playground/actions/runs/22832477226 -->