### PR TITLE
fix(dependency-review): only run on opened/reopened, not synchronize

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,7 +1,7 @@
 name: Dependency Review
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened]
 
 permissions:
   actions: read


### PR DESCRIPTION
## Problem

The `dependency-review.yml` workflow triggers on `[opened, synchronize, reopened]`. The `synchronize` event fires every time dependabot pushes to a PR branch — typically just a rebase to resolve merge conflicts. This caused PR #2114 to receive **two identical Dependency Update Analysis comments** (runs `22830029727` and `22830956851`).

## Root Cause

Dependabot almost never changes the version being bumped on an existing PR. When a newer version is available, it opens a **new PR** rather than updating the old one. So re-running the analysis on `synchronize` produces redundant noise with no new information.

## Fix

Remove `synchronize` from the trigger types — keep only `opened` and `reopened`.

```diff
-    types: [opened, synchronize, reopened]
+    types: [opened, reopened]
```