### PR TITLE
fix(ready-prs): include pull_request_target runs in CI status checks

### DIFF
--- a/scripts/ready-prs.py
+++ b/scripts/ready-prs.py
@@ -159,7 +159,7 @@ def gh_post(endpoint: str, repo_slug: str) -> bool:
 
 def compute_ci_status(runs: list[dict], head_sha: str) -> CIStatus:
     pr_runs = [r for r in runs
-               if r.get("event") == "pull_request" and r.get("headSha") == head_sha]
+               if r.get("event") in ("pull_request", "pull_request_target") and r.get("headSha") == head_sha]
     if not pr_runs:
         return CIStatus.NO_RUNS
     if any(r.get("status") == "action_required" or r.get("conclusion") == "action_required"
@@ -283,7 +283,7 @@ def phase_approve_runs(prs: list[PRInfo], runs: list[dict], ctx: Ctx) -> int:
         if not pr.is_bot or pr.is_wip:
             continue
         blocked = [r for r in runs
-                   if r.get("event") == "pull_request"
+                   if r.get("event") in ("pull_request", "pull_request_target")
                    and r.get("headSha") == pr.head_sha
                    and (r.get("status") == "action_required"
                         or r.get("conclusion") == "action_required")]


### PR DESCRIPTION
## Problem

`ready-prs.py` filters workflow runs to `event == "pull_request"` in two places:

- `compute_ci_status` (line 162) — used to detect `action_required` state
- `phase_approve_runs` (line 286) — used to find runs to approve

Workflows that use `pull_request_target` (e.g. `pr-control-panel.yml`) show up with `event == "pull_request_target"` in the API response. These runs were silently dropped before either check, so the script never detected them as waiting for approval and never attempted to approve them.

## Fix

Change both filters from `== "pull_request"` to `in ("pull_request", "pull_request_target")`.