### PR TITLE
fix(ready-prs): match pull_request_target approval runs by branch, not sha

### DIFF
--- a/scripts/ready-prs.py
+++ b/scripts/ready-prs.py
@@ -284,7 +284,13 @@ def phase_approve_runs(prs: list[PRInfo], runs: list[dict], ctx: Ctx) -> int:
             continue
         blocked = [r for r in runs
                    if r.get("event") in ("pull_request", "pull_request_target")
-                   and r.get("headSha") == pr.head_sha
+                   and (
+                       # pull_request: match by sha (sha is meaningful — run uses PR branch)
+                       (r.get("event") == "pull_request" and r.get("headSha") == pr.head_sha)
+                       # pull_request_target: match by branch (runs off main, sha drifts as
+                       # new commits are pushed without re-triggering a new run)
+                       or (r.get("event") == "pull_request_target" and r.get("headBranch") == pr.branch)
+                   )
                    and (r.get("status") == "action_required"
                         or r.get("conclusion") == "action_required")]
         if not blocked:


### PR DESCRIPTION
## Problem

`phase_approve_runs` matches blocked runs by `headSha == pr.head_sha`. For `pull_request_target` workflows (like `pr-control-panel`), the run is recorded with the sha from when the PR was *first opened*. When Copilot pushes further commits, `pr.head_sha` advances but no new `pull_request_target` run is created (we only trigger on `opened/reopened/labeled/unlabeled` — not `synchronize`).

Result: the run sits at `action_required` forever, invisible to `phase_approve_runs` because the sha no longer matches. PR #2168 is a live example.

## Fix

For `pull_request_target` runs, match by `headBranch == pr.branch` instead of sha. These workflows run off `main`, so the sha is incidental — the branch is the right identity. For `pull_request` runs, keep the existing sha match (those run against the PR branch, where sha identity matters).