### PR TITLE
Harden merge-conflict PR detection in Address Merge Conflicts

### DIFF
--- a/.github/workflows/address-merge-conflicts.yml
+++ b/.github/workflows/address-merge-conflicts.yml
@@ -24,11 +24,11 @@ jobs:
     steps:
       - name: Detect open PRs with merge conflicts
         id: detect
-        uses: elastic/ai-github-actions/.github/actions/get-prs-with-merge-conflicts@8ffdaf1660a1df05770b974f1893355e45c80083
+        uses: elastic/ai-github-actions/.github/actions/get-prs-with-merge-conflicts@46127f22f5181c27e5cdb55beefedae0877cc196
         with:
           github-token: ${{ github.token }}
           settle-seconds: "60"
-          opt-out-label: "no-address-merge-conflicts"
+          exclude-labels: "no-address-merge-conflicts"
 
   address-conflicts:
     needs: detect-conflicted-prs


### PR DESCRIPTION
## Summary
- replace the inline `actions/github-script` conflict-detection script with the reusable `elastic/ai-github-actions/.github/actions/get-prs-with-merge-conflicts` composite action
- pass `settle-seconds: "60"` to allow GitHub's mergeability state to settle before reading it

## Test plan
- reviewed detector logic against the failing run scenario where PR `#2165` is currently `mergeable: CONFLICTING` / `mergeStateStatus: DIRTY`
- ensured workflow output still emits `prs` and `count` in the same shape for downstream matrix job compatibility

Made with [Cursor]((cursor.com/redacted))

---
The body of this PR is automatically managed by the workflow runtime.

---
The body of this PR [is automatically managed](https://ela.st/github-ai-tools) by the [Update PR Body workflow](https://github.com/elastic/ai-github-actions-playground/actions/runs/22835557430).

<!-- gh-aw-agentic-workflow: Update PR Body, engine: copilot, model: gemini-3-flash, id: 22835557430, workflow_id: gh-aw-update-pr-body, run: https://github.com/elastic/ai-github-actions-playground/actions/runs/22835557430 -->