### PR TITLE
Fan out merge-conflict resolution into per-PR workflow_dispatch runs

### DIFF
--- a/.github/workflows/address-merge-conflict.yml
+++ b/.github/workflows/address-merge-conflict.yml
@@ -11,7 +11,6 @@ on:
 permissions:
   actions: read
   contents: write
-  discussions: write
   issues: write
   pull-requests: write
 

--- a/.github/workflows/address-merge-conflicts.yml
+++ b/.github/workflows/address-merge-conflicts.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  actions: read
+  actions: write
   contents: read
   issues: read
   pull-requests: read


### PR DESCRIPTION
## Summary

- Splits the address-merge-conflicts workflow into a **detector** and a **per-PR handler**
- The detector finds conflicted PRs, then dispatches a separate `workflow_dispatch` run for each one via `gh workflow run`
- Each PR gets its own isolated workflow run, avoiding artifact naming collisions that occurred when multiple agent jobs ran as matrix legs in a single run

## Test plan

- [ ] Push to main and verify the detector dispatches individual runs for conflicted PRs
- [ ] Verify each dispatched run resolves its PR's merge conflicts independently


Made with [Cursor](https://cursor.com)