### PR TITLE
Limit PR control panel

### DIFF
--- a/.github/workflows/pr-control-panel.yml
+++ b/.github/workflows/pr-control-panel.yml
@@ -21,10 +21,14 @@ permissions:
 jobs:
   sync-control-panel:
     if: >-
-      github.event_name == 'pull_request_target' ||
+      (github.event_name == 'pull_request_target' &&
+       (github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'COLLABORATOR')) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
-       github.event.sender.login != 'github-actions[bot]')
+       github.event.sender.login != 'github-actions[bot]' &&
+       contains(github.event.comment.body, '<!-- pr-control-panel -->'))
     runs-on: ubuntu-latest
     steps:
       - name: Sync control panel via GitHub API only (no checkout)
@@ -271,6 +275,11 @@ jobs:
             const commentBody = context.payload.comment.body || "";
             if (!commentBody.includes(MARKER)) {
               core.info("Edited comment is not the control panel comment; skipping.");
+              return;
+            }
+            const commentAuthor = context.payload.comment?.user?.login ?? "";
+            if (commentAuthor !== "github-actions[bot]") {
+              core.warning(`Ignoring control-panel edit from non-bot comment (author: ${commentAuthor})`);
               return;
             }
 


### PR DESCRIPTION
## Summary

- **Author association gate**: Only create control panels for PRs from `OWNER`, `MEMBER`, or `COLLABORATOR` — external contributors no longer get control panels
- **Reduce unnecessary runs**: Added `contains(github.event.comment.body, '<!-- pr-control-panel -->')` to the job-level `if` for `issue_comment` events, so GitHub skips the job entirely for irrelevant comment edits (no runner spin-up)
- **Crafted comment defense**: The script now verifies the edited comment was authored by `github-actions[bot]` before processing, preventing external users from crafting their own comment with the marker to trigger label changes

## Test plan

- [ ] Open a PR from a member account — control panel should appear
- [ ] Verify editing a non-control-panel comment does NOT trigger the workflow
- [ ] Verify toggling a control panel checkbox still syncs labels correctly


Made with [Cursor](https://cursor.com)