### PR TITLE
fix(ci): enforce trusted author gates for PR automations

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,6 +1,6 @@
 name: PR Review
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
 permissions:
@@ -12,6 +12,8 @@ permissions:
 jobs:
   run:
     if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'no-pr-review')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-review.lock.yml@main

--- a/.github/workflows/update-pr-body.yml
+++ b/.github/workflows/update-pr-body.yml
@@ -1,6 +1,6 @@
 name: Update PR Body
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
@@ -10,7 +10,11 @@ permissions:
 
 jobs:
   run:
-    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'no-update-pr-body')
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      github.event.pull_request.draft == false &&
+      !contains(github.event.pull_request.labels.*.name, 'no-update-pr-body')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-update-pr-body.lock.yml@main
     with:
       model: gemini-3-flash


### PR DESCRIPTION
## Summary
- switch `Update PR Body` and `PR Review` workflows from `pull_request` to `pull_request_target`
- require PR head repo to match `${{ github.repository }}` before running
- require PR `author_association` to be one of `OWNER`, `MEMBER`, or `COLLABORATOR`
- retain existing draft + opt-out label checks

## Test plan
- [ ] Open/update a same-repo PR from a member/collaborator account and confirm workflows run
- [ ] Confirm forked PRs are skipped by the same-repo gate
- [ ] Confirm non-member/non-collaborator authors are skipped by the association gate
- [ ] Confirm label opt-outs (`no-update-pr-body`, `no-pr-review`) still disable runs

Made with [Cursor](https://cursor.com)