### PR TITLE
fix(ci): allow trusted member fork PRs for review/body workflows

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -12,7 +12,6 @@ permissions:
 jobs:
   run:
     if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'no-pr-review')

--- a/.github/workflows/update-pr-body.yml
+++ b/.github/workflows/update-pr-body.yml
@@ -11,7 +11,6 @@ permissions:
 jobs:
   run:
     if: >-
-      github.event.pull_request.head.repo.full_name == github.repository &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'no-update-pr-body')


### PR DESCRIPTION
## Summary
- remove the same-repo head gate from `PR Review` and `Update PR Body`
- keep `pull_request_target` trigger model and trusted author-association gate
- continue requiring `OWNER` / `MEMBER` / `COLLABORATOR` before automation runs

## Why
The prior same-repo gate unintentionally blocked trusted fork PRs from repo members/collaborators, which defeats the goal of supporting trusted forks.

## Test plan
- [ ] Open/update a fork PR authored by `OWNER`/`MEMBER`/`COLLABORATOR` and confirm `PR Review` + `Update PR Body` run
- [ ] Confirm a fork PR from non-trusted association is skipped
- [ ] Confirm opt-out labels still disable runs

Made with [Cursor](https://cursor.com)