### PR TITLE
fix(ci): gate PR Labeler to trusted pull_request_target

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,6 +1,6 @@
 name: PR Labeler
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
 
 permissions:
@@ -11,7 +11,9 @@ permissions:
 
 jobs:
   run:
-    if: github.event.pull_request.draft == false
+    if: >-
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      github.event.pull_request.draft == false
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-labeler.lock.yml@main
     with:
       model: gemini-3-flash


### PR DESCRIPTION
## Summary
- switch `PR Labeler` from `pull_request` to `pull_request_target`
- add trusted-author gate requiring `OWNER` / `MEMBER` / `COLLABORATOR`
- keep existing draft gating behavior

## Why
Align PR Labeler with the trusted-fork model used by other PR automations so member-owned fork PRs are supported while untrusted authors are skipped.

## Test plan
- [ ] Open/update a same-repo PR by a trusted author and confirm PR Labeler runs
- [ ] Open/update a trusted member fork PR and confirm PR Labeler runs
- [ ] Confirm non-trusted author associations are skipped

Made with [Cursor](https://cursor.com)