### PR TITLE
chore(ci): simplify PR control panel automation summary

### DIFF
--- a/.github/workflows/pr-control-panel.yml
+++ b/.github/workflows/pr-control-panel.yml
@@ -141,38 +141,49 @@ jobs:
             }
 
             function buildControlPanelBody(primaryItems, advancedItems, state, isForkPr) {
+              const managedItems = [...primaryItems, ...advancedItems];
+              const enabledItems = managedItems.filter((item) => state[item.label]);
+              const disabledItems = managedItems.filter((item) => !state[item.label]);
               return [
                 MARKER,
-                "🤖 AI Assistant: I will handle the following tasks for you:",
+                "🤖 AI Assistant 🤖",
                 "",
-                ...(isForkPr
-                  ? [
-                      "_Fork PR detected: controls that require pushing commits are disabled._",
-                      "",
-                    ]
-                  : []),
-                ...primaryItems.map(
-                  (item) =>
-                    `- [${state[item.label] ? "x" : " "}] ${item.displayLabel} <!-- ${KEY_PREFIX}:${item.label} -->`,
-                ),
+                "<details>",
+                `<summary>${enabledItems.length} Enabled Automations • ${disabledItems.length} Disabled Automations</summary>`,
                 "",
-                ...(advancedItems.length > 0
+                ...(enabledItems.length > 0
                   ? [
-                      "<details>",
-                      "<summary>Advanced controls</summary>",
+                      "**Enabled automations**",
                       "",
-                      ...advancedItems.map(
+                      ...enabledItems.map(
                         (item) =>
                           `- [${state[item.label] ? "x" : " "}] ${item.displayLabel} <!-- ${KEY_PREFIX}:${item.label} -->`,
                       ),
                       "",
-                      "</details>",
+                    ]
+                  : []),
+                ...(disabledItems.length > 0
+                  ? [
+                      "**Disabled automations**",
+                      "",
+                      ...disabledItems.map(
+                        (item) =>
+                          `- [${state[item.label] ? "x" : " "}] ${item.displayLabel} <!-- ${KEY_PREFIX}:${item.label} -->`,
+                      ),
                       "",
                     ]
                   : []),
+                "</details>",
+                "",
                 "<details>",
                 "<summary>Troubleshooting</summary>",
                 "",
+                ...(isForkPr
+                  ? [
+                      "Fork PR detected: controls that require pushing commits are intentionally disabled.",
+                      "",
+                    ]
+                  : []),
                 "This control panel only adds or removes labels on the PR.",
                 "It does not directly start workflows.",
                 "If you toggle an option, related automation may not run until its next normal trigger event.",


### PR DESCRIPTION
## Summary
- Update the PR control panel header to `🤖 AI Assistant 🤖`.
- Move automations into a collapsed summary section that shows dynamic enabled/disabled counts.
- Move the fork-specific push-constraint message under the Troubleshooting section.

## Test plan
- [x] Verify the control panel body now renders a collapsed summary with `Enabled` and `Disabled` groups.
- [x] Verify summary counts update from label-derived state.
- [x] Verify fork-specific messaging appears in Troubleshooting instead of the main panel body.

Made with [Cursor](https://cursor.com)