### PR TITLE
fix(ci): fetch action_required runs in ready-prs and add PR explorer workflow

### DIFF
--- a/.github/workflows/explore-pull-request.yml
+++ b/.github/workflows/explore-pull-request.yml
@@ -1,0 +1,127 @@
+name: "Explore: Pull Request"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - ".github/workflows/explore-pull-request.yml"
+      - "peek/src/**"
+      - "peek/tests/**"
+      - "peek/scripts/**"
+      - "peek/package*.json"
+      - "peek/tsconfig*.json"
+      - "peek/vite.config.ts"
+      - "peek/vitest*.ts"
+      - "peek/playwright.config.ts"
+      - "peek/index.html"
+      - "peek/public/**"
+      - "peek/eslint*"
+      - "Makefile"
+
+permissions:
+  actions: read
+  contents: read
+  discussions: write
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: explore-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  run:
+    if: github.event.pull_request.draft == false
+    uses: elastic/ai-github-actions/.github/workflows/gh-aw-internal-gemini-cli.lock.yml@main
+    with:
+      title-prefix: "[explore-pr]"
+      setup-commands: |
+        make serve-explore
+        (cd peek && npx playwright install chromium)
+        cd peek && node scripts/screenshot-section.mjs --section all --live --es-url http://localhost:9200 --url http://localhost:3000/ai-github-actions-playground/ --out-dir screenshots
+      additional-instructions: |
+        You are a **Pull Request QA Explorer** — an AI tester that interactively
+        reviews UI changes introduced by a pull request. Your goal is to catch
+        visual regressions, layout issues, broken interactions, and console
+        errors before the PR is merged.
+
+        ---
+
+        ## Phase 1 — Screenshot evaluation (do this first)
+
+        Pre-generated screenshots of every section (light and dark mode) have
+        been saved to `peek/screenshots/`. List the subdirectories, read each
+        `manifest.json`, then review the screenshot images.
+
+        For every screenshot, check:
+
+        1. **Toolbar element height consistency** — inputs, buttons, and
+           comboboxes in any toolbar should be the same height. A mismatch
+           >4 px is a defect.
+        2. **Dark mode contrast** — sidebar headers, stat card subtitles,
+           table column headers, empty-state helper text, and fieldset legends
+           must be clearly readable against the dark background.
+        3. **Empty state completeness** — any empty-state panel must have an
+           icon, a title, and a description. A blank panel is a defect.
+        4. **Layout defects** — overflowing text, misaligned elements,
+           overlapping UI, or content bleeding outside its container.
+
+        Note every issue before moving to Phase 2.
+
+        ---
+
+        ## Phase 2 — Interactive testing
+
+        The app is running at
+        `http://localhost:3000/ai-github-actions-playground/` with a seeded
+        Elasticsearch cluster at `http://localhost:9200`.
+
+        1. `browser_navigate` to the app URL.
+        2. In the connection dialog, enter `http://localhost:9200` as the
+           Elasticsearch URL, then click **Connect**.
+        3. Explore broadly — do NOT focus on a single section. Visit at least
+           4-5 different pages via the sidebar or direct URL navigation.
+        4. On each page:
+           - `browser_snapshot` to read the DOM structure.
+           - Click interactive elements (buttons, tabs, filters, links).
+           - Check for console errors via `browser_console_execute`.
+           - Toggle dark mode and verify contrast / readability.
+           - `browser_take_screenshot` to capture evidence of any issues.
+        5. Try resizing the viewport to ~800 px width on at least one page to
+           check responsive layout.
+
+        ---
+
+        ## What to look for
+
+        - Visual regressions (mis-styled components, broken icons, wrong colors)
+        - Layout issues (overflow, misalignment, clipped text)
+        - Broken interactions (buttons that don't respond, links that 404)
+        - Console errors or uncaught exceptions
+        - Dark mode contrast problems (near-invisible text)
+        - Stat card label readability (values should be larger than labels)
+        - Fieldset/legend visibility
+
+        ---
+
+        ## Output rules
+
+        This is a **pull request workflow**. Do NOT file a GitHub issue.
+        Instead, post your findings as a **PR comment** using the GitHub API.
+
+        - **If no issues are found:** Post a short comment confirming the UI
+          looks good across the pages you tested. Mention which pages you
+          visited.
+        - **If issues are found:** Post a comment with a numbered list of
+          findings. For each finding include the page/location, what you
+          tried, what you expected, what actually happened, and a screenshot
+          (upload via the API or embed as a base64 image).
+        - Complete ALL exploration phases before posting. Do not stop after
+          the first problem — collect everything, then post once.
+        - **Silence is better than noise.** Only report genuine defects, not
+          cosmetic preferences.
+        - If the UI differs from what this prompt describes but is itself
+          correct, note that in a "Prompt Suggestions" section at the end
+          of your comment.
+    secrets:
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}

--- a/peek/scripts/screenshot-section.mjs
+++ b/peek/scripts/screenshot-section.mjs
@@ -170,7 +170,10 @@ async function captureThemeScreenshots(browser, opts, pages, themeMode, outDir) 
         continue;
       }
 
-      await page.getByRole("button", { name: navButton, exact: true }).click();
+      await page
+        .getByRole("navigation", { name: /main navigation/i })
+        .getByRole("button", { name: navButton, exact: true })
+        .click();
       // Wait for client-side route change to take effect. Some pages (e.g.
       // profiling focus picker) don't trigger network requests, so networkidle
       // alone resolves instantly. A brief wait lets React render the new route

--- a/scripts/ready-prs.py
+++ b/scripts/ready-prs.py
@@ -220,8 +220,14 @@ _PR_FIELDS = "number,title,isDraft,author,headRefOid,headRefName,mergeable,revie
 
 
 def fetch_runs(ctx: Ctx) -> list[dict]:
-    return gh_json("run", "list", "--limit", "200", "--json", _RUN_FIELDS,
-                   repo=ctx.repo_args)
+    # The default gh run list omits action_required runs, so fetch them
+    # separately and merge (deduplicating by run ID).
+    default = gh_json("run", "list", "--limit", "200", "--json", _RUN_FIELDS,
+                      repo=ctx.repo_args) or []
+    pending = gh_json("run", "list", "--limit", "200", "--status", "action_required",
+                      "--json", _RUN_FIELDS, repo=ctx.repo_args) or []
+    seen = {r["databaseId"] for r in default}
+    return default + [r for r in pending if r["databaseId"] not in seen]
 
 
 def fetch_prs(ctx: Ctx) -> list[PRInfo]:


### PR DESCRIPTION
## Summary

- **ready-prs.py**: `gh run list` silently omits `action_required` runs from its default output, so `pull_request_target` workflows (PR Control Panel, PR Labeler, Deploy PR previews, PR Review, Update PR Body) were never getting approved by `phase_approve_runs`. Fix by also fetching `--status action_required` runs and merging them deduplicated.
- **screenshot-section.mjs**: Scope nav button clicks to the `<nav aria-label="Main navigation">` landmark to avoid Playwright strict-mode violations when a table column header shares the same button name (e.g. "Indices" on the Data Streams page).
- **explore-pull-request.yml**: New workflow that runs a Gemini agent with Playwright MCP on every PR. The agent reviews pre-generated screenshots and interactively tests the UI, then posts findings as a PR comment.

## Test plan

- [x] `python3 scripts/ready-prs.py --dry-run` now shows `PR Control Panel` in the "would approve" output
- [ ] Verify PR Control Panel runs get approved on the next `ready-prs.py` execution
- [ ] Verify `explore-pull-request.yml` triggers on this PR and the agent posts a comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)