### PR TITLE
fix(ci): allow trusted bots through pull_request_target gates

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -19,7 +19,8 @@ concurrency:
 jobs:
   deploy-preview:
     if: >-
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association)
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+      contains(fromJSON('["Copilot","dependabot[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/pr-control-panel.yml
+++ b/.github/workflows/pr-control-panel.yml
@@ -22,9 +22,8 @@ jobs:
   sync-control-panel:
     if: >-
       (github.event_name == 'pull_request_target' &&
-       (github.event.pull_request.author_association == 'OWNER' ||
-        github.event.pull_request.author_association == 'MEMBER' ||
-        github.event.pull_request.author_association == 'COLLABORATOR')) ||
+       (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+        contains(fromJSON('["Copilot","dependabot[bot]","github-actions[bot]"]'), github.event.pull_request.user.login))) ||
       (github.event_name == 'issue_comment' &&
        github.event.issue.pull_request != null &&
        github.event.sender.login != 'github-actions[bot]' &&

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -12,7 +12,8 @@ permissions:
 jobs:
   run:
     if: >-
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+      contains(fromJSON('["Copilot","dependabot[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)) &&
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'no-pr-labeler')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-labeler.lock.yml@main

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -12,7 +12,8 @@ permissions:
 jobs:
   run:
     if: >-
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+      contains(fromJSON('["Copilot","dependabot[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)) &&
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'no-pr-review')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-pr-review.lock.yml@main

--- a/.github/workflows/update-pr-body.yml
+++ b/.github/workflows/update-pr-body.yml
@@ -11,7 +11,8 @@ permissions:
 jobs:
   run:
     if: >-
-      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) &&
+      (contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.pull_request.author_association) ||
+      contains(fromJSON('["Copilot","dependabot[bot]","github-actions[bot]"]'), github.event.pull_request.user.login)) &&
       github.event.pull_request.draft == false &&
       !contains(github.event.pull_request.labels.*.name, 'no-update-pr-body')
     uses: elastic/ai-github-actions/.github/workflows/gh-aw-update-pr-body.lock.yml@main


### PR DESCRIPTION
## Summary

- Copilot, dependabot[bot], and github-actions[bot] have `author_association: CONTRIBUTOR`, not `COLLABORATOR`, so all `pull_request_target` workflows were skipping their PRs entirely — producing `action_required` runs that could never succeed.
- Adds a fallback `user.login` check for these trusted bots in all 5 affected workflows: PR Control Panel, PR Labeler, PR Review, Update PR Body, and Deploy PR previews.
- Uses array `contains()` (exact match on array elements) to allowlist specific bot logins.

## Affected workflows

| Workflow | File |
|----------|------|
| PR Control Panel | `pr-control-panel.yml` |
| PR Labeler | `pr-labeler.yml` |
| PR Review | `pr-review.yml` |
| Update PR Body | `update-pr-body.yml` |
| Deploy PR previews | `deploy-pr-preview.yml` |

## Test plan

- [ ] Verify a Copilot PR (e.g. `copilot/*` branch) triggers all 5 workflows successfully instead of going to `action_required`
- [ ] Verify a dependabot PR triggers correctly
- [ ] Verify a human PR still works as before (matches via `author_association`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)