### PR TITLE
feat(ci): add reset toggle to PR control panel

### DIFF
--- a/.github/workflows/pr-control-panel.yml
+++ b/.github/workflows/pr-control-panel.yml
@@ -186,6 +186,8 @@ jobs:
                 "This control panel only adds or removes labels on the PR.",
                 "It does not directly start workflows.",
                 "If you toggle an option, related automation may not run until its next normal trigger event.",
+                "",
+                "- [ ] Re-sync control panel from labels <!-- action:reset -->",
                 "</details>",
               ].join("\n");
             }
@@ -366,15 +368,26 @@ jobs:
             const pr = await getPullRequest(issueNumber);
             const panelConfig = getPanelConfig(pr);
             const labels = new Set((pr.labels || []).map((l) => l.name));
-            const currentState = Object.fromEntries(
+
+            // Check if the reset toggle was checked
+            const resetRequested = /- \[[xX]\][^\n]*<!--\s*action:reset\s*-->/.test(commentBody);
+
+            // Labels are always the baseline; checkboxes override unless resetting
+            const labelState = Object.fromEntries(
               panelConfig.managedItems.map((item) => [item.label, !labels.has(item.label)]),
             );
-            const desiredState = Object.fromEntries(
-              panelConfig.managedItems.map((item) => [
-                item.label,
-                readCheckboxByKey(commentBody, item.label) ?? currentState[item.label],
-              ]),
-            );
+            const desiredState = resetRequested
+              ? labelState
+              : Object.fromEntries(
+                  panelConfig.managedItems.map((item) => [
+                    item.label,
+                    readCheckboxByKey(commentBody, item.label) ?? labelState[item.label],
+                  ]),
+                );
+
+            if (resetRequested) {
+              core.info("Reset requested — rebuilding control panel from labels");
+            }
 
             await syncLabelsFromState(issueNumber, labels, desiredState, panelConfig);
             await upsertControlPanel(issueNumber, panelConfig, desiredState);


### PR DESCRIPTION
## Summary

- Adds a **Re-sync control panel from labels** checkbox in the Troubleshooting section of the PR control panel comment
- When checked and saved, the workflow rebuilds the entire control panel using PR labels as the sole source of truth, ignoring checkbox state
- The toggle auto-clears after reset since the rebuilt comment always renders it unchecked
- Gives a one-click way to re-sync the panel when options get out of sync or new automations are added

## Test plan

- [ ] Open an existing PR's control panel comment, expand Troubleshooting, check the reset box, save
- [ ] Verify the comment is rebuilt with checkboxes matching the current label state
- [ ] Verify the reset checkbox is unchecked again after the rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)