### PR TITLE
fix: exclude agent worktrees from vitest test discovery

### DIFF
--- a/peek/vitest.config.ts
+++ b/peek/vitest.config.ts
@@ -2,6 +2,8 @@ import { defineConfig } from "vitest/config";
 
 export default defineConfig({
   test: {
+    // Exclude agent worktrees so nested project copies don't pollute test runs.
+    exclude: ["**/.claude/**", "**/.copilot/**", "**/node_modules/**"],
     projects: [
       {
         extends: true,


### PR DESCRIPTION
## Summary
- Vitest's glob include patterns (e.g. `tests/unit/**/*.test.ts`) match files inside `.claude/worktrees/` and `.copilot/worktrees/` subdirectories, causing tests from nested agent worktrees to pollute test runs
- Adds a top-level `exclude` to `vitest.config.ts` for `**/.claude/**`, `**/.copilot/**`, and `**/node_modules/**` so each worktree only runs its own tests

## Test plan
- [ ] Run `npx vitest run` from the repo root — should only discover tests in `peek/tests/`, not from any `.claude/worktrees/` or `.copilot/worktrees/` paths
- [ ] Run tests from inside an agent worktree — should still work normally (the exclude is relative, so the worktree's own tests are not excluded from within)

🤖 Generated with [Claude Code](https://claude.com/claude-code)