### PR TITLE
feat: scheduled demo environment seeder

### DIFF
--- a/.github/workflows/seed-demo.yml
+++ b/.github/workflows/seed-demo.yml
@@ -38,14 +38,20 @@ jobs:
       - name: Wait for collector health
         run: |
           echo "Waiting for EDOT collector to be healthy..."
+          healthy=false
           for i in $(seq 1 30); do
             if docker compose -f docker-compose.otel.yml exec -T otel-collector \
               curl -sf http://localhost:13133/ >/dev/null 2>&1; then
               echo "✓ Collector healthy after ${i}0s"
+              healthy=true
               break
             fi
             sleep 10
           done
+          if [ "$healthy" != "true" ]; then
+            echo "::error::Collector failed to become healthy after 300s"
+            exit 1
+          fi
 
       - uses: actions/setup-node@v4
         with:
@@ -55,20 +61,16 @@ jobs:
         run: cd peek && npm ci --ignore-scripts
 
       - name: Seed non-OTLP data (web_logs, orders, pipelines, transforms)
-        env:
-          ES_API_KEY: ${{ secrets.DEMO_WRITE_API_KEY }}
         run: |
           node peek/scripts/seed-elasticsearch.mjs \
             --url "${ES_URL}" \
-            --api-key "${ES_API_KEY}"
+            --api-key "${{ secrets.DEMO_WRITE_API_KEY }}"
 
       - name: Seed Kubernetes OTel data
-        env:
-          ES_API_KEY: ${{ secrets.DEMO_WRITE_API_KEY }}
         run: |
           node peek/scripts/seed-k8s.mjs \
             --url "${ES_URL}" \
-            --api-key "${ES_API_KEY}"
+            --api-key "${{ secrets.DEMO_WRITE_API_KEY }}"
 
       - name: Let generators run for ${{ env.TRACEGEN_DURATION }} minutes
         run: |

--- a/.github/workflows/seed-demo.yml
+++ b/.github/workflows/seed-demo.yml
@@ -1,0 +1,92 @@
+name: Seed Demo Environment
+
+on:
+  schedule:
+    # Every 6 hours — keeps trace/log/metric data fresh in the demo cluster
+    - cron: "0 */6 * * *"
+  workflow_dispatch:
+    inputs:
+      tracegen_duration:
+        description: "How long to run trace generators (minutes)"
+        required: false
+        default: "20"
+
+concurrency:
+  group: seed-demo
+  cancel-in-progress: true
+
+env:
+  ES_URL: https://elastic-peek-010bd2.es.us-central1.gcp.cloud.es.io/
+  TRACEGEN_DURATION: ${{ inputs.tracegen_duration || '20' }}
+
+jobs:
+  seed:
+    name: Seed demo cluster
+    runs-on: ubuntu-latest
+    if: github.repository == 'elastic/ai-github-actions-playground'
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Start OTel stack (collector + tracegen + otelgen-logs)
+        env:
+          ES_API_KEY: ${{ secrets.DEMO_WRITE_API_KEY }}
+        run: |
+          docker compose -f docker-compose.otel.yml up -d
+          echo "✓ OTel stack started — sending to $ES_URL"
+
+      - name: Wait for collector health
+        run: |
+          echo "Waiting for EDOT collector to be healthy..."
+          for i in $(seq 1 30); do
+            if docker compose -f docker-compose.otel.yml exec -T otel-collector \
+              curl -sf http://localhost:13133/ >/dev/null 2>&1; then
+              echo "✓ Collector healthy after ${i}0s"
+              break
+            fi
+            sleep 10
+          done
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install peek dependencies
+        run: cd peek && npm ci --ignore-scripts
+
+      - name: Seed non-OTLP data (web_logs, orders, pipelines, transforms)
+        env:
+          ES_API_KEY: ${{ secrets.DEMO_WRITE_API_KEY }}
+        run: |
+          node peek/scripts/seed-elasticsearch.mjs \
+            --url "${ES_URL}" \
+            --api-key "${ES_API_KEY}"
+
+      - name: Seed Kubernetes OTel data
+        env:
+          ES_API_KEY: ${{ secrets.DEMO_WRITE_API_KEY }}
+        run: |
+          node peek/scripts/seed-k8s.mjs \
+            --url "${ES_URL}" \
+            --api-key "${ES_API_KEY}"
+
+      - name: Let generators run for ${{ env.TRACEGEN_DURATION }} minutes
+        run: |
+          echo "Generators running — waiting ${TRACEGEN_DURATION} minutes..."
+          sleep "${TRACEGEN_DURATION}m"
+
+      - name: Show generator stats
+        if: always()
+        run: |
+          echo "=== Collector logs (last 30 lines) ==="
+          docker compose -f docker-compose.otel.yml logs --tail=30 otel-collector
+          echo ""
+          echo "=== Tracegen logs (last 10 lines) ==="
+          docker compose -f docker-compose.otel.yml logs --tail=10 tracegen
+          echo ""
+          echo "=== Log generator logs (last 10 lines) ==="
+          docker compose -f docker-compose.otel.yml logs --tail=10 otelgen-logs
+
+      - name: Stop OTel stack
+        if: always()
+        run: docker compose -f docker-compose.otel.yml down -v

--- a/.github/workflows/seed-demo.yml
+++ b/.github/workflows/seed-demo.yml
@@ -24,7 +24,7 @@ jobs:
     name: Seed demo cluster
     runs-on: ubuntu-latest
     if: github.repository == 'elastic/ai-github-actions-playground'
-    timeout-minutes: 30
+    timeout-minutes: 40
     steps:
       - uses: actions/checkout@v4
 

--- a/peek/scripts/seed-elasticsearch.mjs
+++ b/peek/scripts/seed-elasticsearch.mjs
@@ -24,12 +24,14 @@ import { Client } from "@elastic/elasticsearch";
 function parseArgs(argv) {
   const opts = {
     url: process.env.ES_URL ?? "http://localhost:9200",
+    apiKey: process.env.ES_API_KEY ?? "",
     waitForReady: false,
   };
 
   for (let i = 0; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === "--url" && argv[i + 1]) opts.url = argv[++i];
+    else if (arg === "--api-key" && argv[i + 1]) opts.apiKey = argv[++i];
     else if (arg === "--wait-for-ready") opts.waitForReady = true;
   }
 
@@ -272,7 +274,9 @@ async function run() {
   const opts = parseArgs(process.argv.slice(2));
   console.log(`Seeding Elasticsearch at ${opts.url}...`);
 
-  const client = new Client({ node: opts.url });
+  const clientOpts = { node: opts.url };
+  if (opts.apiKey) clientOpts.auth = { apiKey: opts.apiKey };
+  const client = new Client(clientOpts);
 
   if (opts.waitForReady) {
     console.log("  Waiting for Elasticsearch to be ready...");

--- a/peek/scripts/seed-k8s.mjs
+++ b/peek/scripts/seed-k8s.mjs
@@ -28,10 +28,12 @@ import { Client } from "@elastic/elasticsearch";
 function parseArgs(argv) {
   const opts = {
     url: process.env.ES_URL ?? "http://localhost:9200",
+    apiKey: process.env.ES_API_KEY ?? "",
     waitForReady: false,
   };
   for (let i = 0; i < argv.length; i++) {
     if (argv[i] === "--url" && argv[i + 1]) opts.url = argv[++i];
+    else if (argv[i] === "--api-key" && argv[i + 1]) opts.apiKey = argv[++i];
     else if (argv[i] === "--wait-for-ready") opts.waitForReady = true;
   }
   return opts;
@@ -380,7 +382,9 @@ async function seedK8sTraces(client, pods) {
 // ---------------------------------------------------------------------------
 
 const opts = parseArgs(process.argv.slice(2));
-const client = new Client({ node: opts.url });
+const clientOpts = { node: opts.url };
+if (opts.apiKey) clientOpts.auth = { apiKey: opts.apiKey };
+const client = new Client(clientOpts);
 
 if (opts.waitForReady) {
   console.log("Waiting for Elasticsearch to be ready...");


### PR DESCRIPTION
## Summary
- Adds a `seed-demo` workflow that runs **every 6 hours** (and on manual dispatch) to keep the demo cluster at `elastic-peek-010bd2.es.us-central1.gcp.cloud.es.io` populated with fresh telemetry
- Reuses the existing `docker-compose.otel.yml` stack: EDOT collector + tracegen (12 e-commerce microservices) + otelgen-logs
- Also runs `seed-elasticsearch.mjs` (web_logs, orders, pipelines, transforms) and `seed-k8s.mjs` (k8s pods, containers, namespaces) against the demo cluster
- Adds `--api-key` flag to both seed scripts so they can authenticate against remote clusters

## Why
The demo environment currently has no recent trace data, which means features like the **instrumentation score** on the Services page don't render (they require traces within the selected time window).

## Setup required
Add a `DEMO_WRITE_API_KEY` repository secret with an API key that has write access to the demo cluster.

## Test plan
- [ ] Add `DEMO_WRITE_API_KEY` secret to the repo
- [ ] Trigger the workflow manually via Actions → Seed Demo Environment → Run workflow
- [ ] Verify traces appear on the Services page in the demo
- [ ] Verify instrumentation score panel renders for services like `frontend-web`, `api-gateway`

🤖 Generated with [Claude Code](https://claude.com/claude-code)